### PR TITLE
Run ruby 2.3 on travis to match ManageIQ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-- 2.4.2
+- 2.4.4
+- 2.3.6
 addons:
   postgresql: '9.5'
 env:


### PR DESCRIPTION
Match the versions of ruby that travis runs for the ManageIQ repo