### PR TITLE
Infer parent inventory collections automatically

### DIFF
--- a/lib/inventory_refresh/inventory_collection.rb
+++ b/lib/inventory_refresh/inventory_collection.rb
@@ -1116,12 +1116,12 @@ module InventoryRefresh
 
     # @return true if it's a noop parent targeted InventoryCollection
     def saving_targeted_parent_collection_noop?
-      targeted_noop_condition && parent_inventory_collections.nil? && targeted_scope.primary_references.blank?
+      targeted_noop_condition && parent_inventory_collections.blank? && targeted_scope.primary_references.blank?
     end
 
     # @return true if it's a noop child targeted InventoryCollection
     def saving_targeted_child_collection_noop?
-      targeted_noop_condition && !parent_inventory_collections.nil? &&
+      targeted_noop_condition && parent_inventory_collections.present? &&
         parent_inventory_collections.all? { |x| x.targeted_scope.primary_references.blank? }
     end
 

--- a/lib/inventory_refresh/inventory_collection/graph.rb
+++ b/lib/inventory_refresh/inventory_collection/graph.rb
@@ -52,25 +52,10 @@ module InventoryRefresh
         # depth 10. We should throw a warning maybe asking for simplifying the interconnections in the models.
         assert_graph!(edges)
 
-        self.nodes = sort_nodes(nodes)
-
         self
       end
 
       private
-
-      # Sort the nodes putting child nodes as last. Child nodes are InventoryCollection objects having
-      # :parent_inventory_collections definition.
-      #
-      # @param nodes [Array<InventoryRefresh::InventoryCollection>] List of Inventory collection nodes
-      # @return [Array<InventoryRefresh::InventoryCollection>] Sorted list of Inventory collection nodes
-      def sort_nodes(nodes)
-        # Separate to root nodes and child nodes, where child nodes are determined by having parent_inventory_collections
-        root_nodes, child_nodes = nodes.partition { |node| node.parent_inventory_collections.blank? }
-        # And order it that root nodes comes first, that way the disconnect of the child nodes should be always done as
-        # a part of the root nodes, as intended.
-        root_nodes + child_nodes
-      end
 
       # Asserts all nodes are of class ::InventoryRefresh::InventoryCollection
       #

--- a/lib/inventory_refresh/inventory_collection/scanner.rb
+++ b/lib/inventory_refresh/inventory_collection/scanner.rb
@@ -91,12 +91,7 @@ module InventoryRefresh
 
       def build_parent_inventory_collections!
         if parent_inventory_collections.nil?
-          if association.present? && parent.present? && associations_hash[association].present?
-            # Add immediate parent IC as dependency
-            add_parent_inventory_collection_dependency!(associations_hash[association])
-            # Add root IC in parent_inventory_collections
-            self.parent_inventory_collections = [find_parent_inventory_collection(associations_hash, inventory_collection.association)]
-          end
+          build_parent_inventory_collection!
         else
           # We can't figure out what immediate parent is, we'll add parent_inventory_collections as dependencies
           parent_inventory_collections.each { |ic_name| add_parent_inventory_collection_dependency!(ic_name) }
@@ -106,6 +101,15 @@ module InventoryRefresh
 
         # Transform InventoryCollection object names to actual objects
         self.parent_inventory_collections = parent_inventory_collections.map { |x| load_inventory_collection_by_name(x) }
+      end
+
+      def build_parent_inventory_collection!
+        if association.present? && parent.present? && associations_hash[association].present?
+          # Add immediate parent IC as dependency
+          add_parent_inventory_collection_dependency!(associations_hash[association])
+          # Add root IC in parent_inventory_collections
+          self.parent_inventory_collections = [find_parent_inventory_collection(associations_hash, inventory_collection.association)]
+        end
       end
 
       def add_parent_inventory_collection_dependency!(ic_name)

--- a/lib/inventory_refresh/inventory_collection/scanner.rb
+++ b/lib/inventory_refresh/inventory_collection/scanner.rb
@@ -53,9 +53,12 @@ module InventoryRefresh
 
       # The data scanner modifies inside of the :inventory_collection
       delegate :association,
+               :arel,
                :attribute_references,
+               :custom_save_block,
                :data_collection_finalized=,
                :dependency_attributes,
+               :targeted?,
                :targeted_scope,
                :parent,
                :parent_inventory_collections,
@@ -104,6 +107,11 @@ module InventoryRefresh
       end
 
       def build_parent_inventory_collection!
+        # Don't try to introspect ICs with custom query or saving code
+        return if arel.present? || custom_save_block.present?
+        # We support :parent_inventory_collections only for targeted mode, where all ICs are present
+        return unless targeted?
+
         if association.present? && parent.present? && associations_hash[association].present?
           # Add immediate parent IC as dependency
           add_parent_inventory_collection_dependency!(associations_hash[association])

--- a/lib/inventory_refresh/inventory_collection/scanner.rb
+++ b/lib/inventory_refresh/inventory_collection/scanner.rb
@@ -12,8 +12,6 @@ module InventoryRefresh
         def scan!(inventory_collections)
           indexed_inventory_collections = inventory_collections.index_by(&:name)
 
-          # TODO(lsmola) build parent inventory collections automatically here
-
           inventory_collections.each do |inventory_collection|
             new(inventory_collection, indexed_inventory_collections, build_association_hash(inventory_collections)).scan!
           end

--- a/lib/inventory_refresh/inventory_collection/scanner.rb
+++ b/lib/inventory_refresh/inventory_collection/scanner.rb
@@ -107,10 +107,7 @@ module InventoryRefresh
       end
 
       def build_parent_inventory_collection!
-        # Don't try to introspect ICs with custom query or saving code
-        return if arel.present? || custom_save_block.present?
-        # We support :parent_inventory_collections only for targeted mode, where all ICs are present
-        return unless targeted?
+        return unless supports_building_inventory_collection?
 
         if association.present? && parent.present? && associations_hash[association].present?
           # Add immediate parent IC as dependency
@@ -118,6 +115,15 @@ module InventoryRefresh
           # Add root IC in parent_inventory_collections
           self.parent_inventory_collections = [find_parent_inventory_collection(associations_hash, inventory_collection.association)]
         end
+      end
+
+      def supports_building_inventory_collection?
+        # Don't try to introspect ICs with custom query or saving code
+        return if arel.present? || custom_save_block.present?
+        # We support :parent_inventory_collections only for targeted mode, where all ICs are present
+        return unless targeted?
+
+        true
       end
 
       def add_parent_inventory_collection_dependency!(ic_name)

--- a/lib/inventory_refresh/inventory_collection/scanner.rb
+++ b/lib/inventory_refresh/inventory_collection/scanner.rb
@@ -122,7 +122,7 @@ module InventoryRefresh
 
       def add_parent_inventory_collection_dependency!(ic_name)
         ic = load_inventory_collection_by_name(ic_name)
-        (dependency_attributes[:__parent_inventory_collections] ||= Set.new) << ic
+        (dependency_attributes[:__parent_inventory_collections] ||= Set.new) << ic if ic
       end
 
       def find_parent_inventory_collection(hash, name)
@@ -136,7 +136,7 @@ module InventoryRefresh
       def load_inventory_collection_by_name(name)
         ic = indexed_inventory_collections[name]
         if ic.nil?
-          raise "Can't find InventoryCollection :#{name} referenced from #{inventory_collection}"
+          raise "Can't find InventoryCollection :#{name} referenced from #{inventory_collection}" if targeted?
         end
         ic
       end

--- a/lib/inventory_refresh/inventory_collection/scanner.rb
+++ b/lib/inventory_refresh/inventory_collection/scanner.rb
@@ -106,6 +106,7 @@ module InventoryRefresh
         self.parent_inventory_collections = parent_inventory_collections.map do |ic_name|
           ic = load_inventory_collection_by_name(ic_name)
 
+          # TODO(lsmola) the dependency should be the immediate parent, not the parent inventory collection?
           (dependency_attributes[:__parent_inventory_collections] ||= Set.new) << ic
           ic
         end

--- a/spec/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -608,7 +608,10 @@ describe InventoryRefresh::SaveInventory do
         builder.add_properties(:model_class => ManageIQ::Providers::CloudManager::Vm)
       end
       @persister.add_collection(:hardwares) do |builder|
-        builder.add_properties(:manager_ref => %i(virtualization_type))
+        builder.add_properties(
+          :manager_ref                  => %i(virtualization_type),
+          :parent_inventory_collections => %i(vms)
+        )
       end
     end
 
@@ -689,7 +692,10 @@ describe InventoryRefresh::SaveInventory do
         builder.add_properties(:model_class => ManageIQ::Providers::CloudManager::Vm)
       end
       @persister.add_collection(:hardwares) do |builder|
-        builder.add_properties(:manager_ref => %i(vm_or_template virtualization_type))
+        builder.add_properties(
+          :manager_ref                  => %i(vm_or_template virtualization_type),
+          :parent_inventory_collections => %i(vms)
+        )
       end
 
       @vm_data_1 = vm_data(1)
@@ -765,13 +771,22 @@ describe InventoryRefresh::SaveInventory do
       builder.add_properties(:model_class => ManageIQ::Providers::CloudManager::Template)
     end
     @persister.add_collection(:hardwares) do |builder|
-      builder.add_properties(:manager_ref => %i(vm_or_template))
+      builder.add_properties(
+        :manager_ref                  => %i(vm_or_template),
+        :parent_inventory_collections => %i(vms miq_templates)
+      )
     end
     @persister.add_collection(:disks) do |builder|
-      builder.add_properties(:manager_ref => %i(hardware device_name))
+      builder.add_properties(
+        :manager_ref                  => %i(hardware device_name),
+        :parent_inventory_collections => %i(vms miq_templates)
+      )
     end
     @persister.add_collection(:networks) do |builder|
-      builder.add_properties(:manager_ref => %i(hardware description))
+      builder.add_properties(
+        :manager_ref                  => %i(hardware description),
+        :parent_inventory_collections => %i(vms miq_templates)
+      )
     end
     @persister.add_collection(:flavors) do |builder|
       builder.add_properties(

--- a/spec/save_inventory/build_parent_inventory_collections_spec.rb
+++ b/spec/save_inventory/build_parent_inventory_collections_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 require_relative '../helpers/spec_parsed_data'
-require_relative '../persister/test_persister'
+require_relative '../helpers/test_persister'
 
 describe InventoryRefresh::SaveInventory do
   include SpecHelper
@@ -15,21 +15,21 @@ describe InventoryRefresh::SaveInventory do
                               :network_manager => FactoryGirl.create(:ems_network))
   end
 
-  let(:persister_class) { ::TestPersister }
+  let(:persister_class) { ::TestPersister::Cloud }
   let(:persister) { persister_class.new(@ems, @ems) }
 
   it "checks parent inventory collections defined manually are not overwritten" do
     # Add blank presisters
-    persister.add_collection(persister.cloud, :vms_and_templates) do |x|
+    persister.add_collection(:vms_and_templates) do |x|
       x.add_properties(:model_class => VmOrTemplate)
     end
-    persister.add_collection(persister.cloud, :hardwares) do |x|
+    persister.add_collection(:hardwares) do |x|
       x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => %i(vms_and_templates))
     end
-    persister.add_collection(persister.cloud, :disks) do |x|
+    persister.add_collection(:disks) do |x|
       x.add_properties(:manager_ref => %i(hardware device_name), :parent_inventory_collections => %i(vms_and_templates))
     end
-    persister.add_collection(persister.cloud, :networks) do |x|
+    persister.add_collection(:networks) do |x|
       x.add_properties(:manager_ref => %i(hardware description), :parent_inventory_collections => %i(vms_and_templates))
     end
 
@@ -64,16 +64,16 @@ describe InventoryRefresh::SaveInventory do
 
   it "checks parent inventory collections are built correctly based on the model relations" do
     # Add blank presisters
-    persister.add_collection(persister.cloud, :vms_and_templates) do |x|
+    persister.add_collection(:vms_and_templates) do |x|
       x.add_properties(:model_class => VmOrTemplate)
     end
-    persister.add_collection(persister.cloud, :hardwares) do |x|
+    persister.add_collection(:hardwares) do |x|
       x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => nil)
     end
-    persister.add_collection(persister.cloud, :disks) do |x|
+    persister.add_collection(:disks) do |x|
       x.add_properties(:manager_ref => %i(hardware device_name), :parent_inventory_collections => nil)
     end
-    persister.add_collection(persister.cloud, :networks) do |x|
+    persister.add_collection(:networks) do |x|
       x.add_properties(:manager_ref => %i(hardware description), :parent_inventory_collections => nil)
     end
 
@@ -112,16 +112,16 @@ describe InventoryRefresh::SaveInventory do
 
   it "checks parent inventory collections are not overwritten when set as []" do
     # Add blank presisters
-    persister.add_collection(persister.cloud, :vms_and_templates) do |x|
+    persister.add_collection(:vms_and_templates) do |x|
       x.add_properties(:model_class => VmOrTemplate, :parent_inventory_collections => [])
     end
-    persister.add_collection(persister.cloud, :hardwares) do |x|
+    persister.add_collection(:hardwares) do |x|
       x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => [])
     end
-    persister.add_collection(persister.cloud, :disks) do |x|
+    persister.add_collection(:disks) do |x|
       x.add_properties(:manager_ref => %i(hardware device_name), :parent_inventory_collections => [])
     end
-    persister.add_collection(persister.cloud, :networks) do |x|
+    persister.add_collection(:networks) do |x|
       x.add_properties(:manager_ref => %i(hardware description), :parent_inventory_collections => [])
     end
 
@@ -140,7 +140,7 @@ describe InventoryRefresh::SaveInventory do
   end
 
   it "checks error is thrown for non-existent inventory collection" do
-    persister.add_collection(persister.cloud, :hardwares) do |x|
+    persister.add_collection(:hardwares) do |x|
       x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => %i(random_name))
     end
 

--- a/spec/save_inventory/build_parent_inventory_collections_spec.rb
+++ b/spec/save_inventory/build_parent_inventory_collections_spec.rb
@@ -95,10 +95,10 @@ describe InventoryRefresh::SaveInventory do
       match_array([indexed_ics[:vms_and_templates]])
     )
     expect(indexed_ics[:disks].dependencies).to(
-      match_array([indexed_ics[:vms_and_templates]])
+      match_array([indexed_ics[:hardwares]])
     )
     expect(indexed_ics[:networks].dependencies).to(
-      match_array([indexed_ics[:vms_and_templates]])
+      match_array([indexed_ics[:hardwares]])
     )
   end
 

--- a/spec/save_inventory/build_parent_inventory_collections_spec.rb
+++ b/spec/save_inventory/build_parent_inventory_collections_spec.rb
@@ -1,0 +1,133 @@
+require_relative 'spec_helper'
+require_relative '../helpers/spec_parsed_data'
+require_relative '../persister/test_base_persister'
+
+describe InventoryRefresh::SaveInventory do
+  include SpecHelper
+  include SpecParsedData
+
+  ######################################################################################################################
+  # Spec scenarios building parent_inventory_collections parameter automatically
+  ######################################################################################################################
+  #
+  before do
+    @ems = FactoryGirl.create(:ems_cloud,
+                              :network_manager => FactoryGirl.create(:ems_network))
+  end
+
+  let(:persister_class) { ::TestBasePersister }
+  let(:persister) { persister_class.new(@ems, @ems) }
+
+  it "checks parent inventory collections defined manually are not overwritten" do
+    # Add blank presisters
+    persister.add_collection(:vms_and_templates) do |x|
+      x.add_properties(:model_class => VmOrTemplate)
+    end
+    persister.add_collection(:hardwares) do |x|
+      x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => %i(vms_and_templates))
+    end
+    persister.add_collection(:disks) do |x|
+      x.add_properties(:manager_ref => %i(hardware device_name), :parent_inventory_collections => %i(vms_and_templates))
+    end
+    persister.add_collection(:networks) do |x|
+      x.add_properties(:manager_ref => %i(hardware description), :parent_inventory_collections => %i(vms_and_templates))
+    end
+
+    indexed_ics = persister.inventory_collections.index_by(&:name)
+
+    InventoryRefresh::InventoryCollection::Scanner.scan!(persister.inventory_collections)
+
+    # Check parent inventory collections
+    expect(indexed_ics[:vms_and_templates].parent_inventory_collections).to be_nil
+    expect(indexed_ics[:hardwares].parent_inventory_collections).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+    expect(indexed_ics[:disks].parent_inventory_collections).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+    expect(indexed_ics[:networks].parent_inventory_collections).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+
+    # Check dependencies
+    expect(indexed_ics[:vms_and_templates].dependencies).to eq([])
+    expect(indexed_ics[:hardwares].dependencies).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+    expect(indexed_ics[:disks].dependencies).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+    expect(indexed_ics[:networks].dependencies).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+  end
+
+  it "checks parent inventory collections are built correctly based on the model relations" do
+    # Add blank presisters
+    persister.add_collection(:vms_and_templates) { |x| x.add_properties(:model_class => VmOrTemplate) }
+    persister.add_collection(:hardwares) { |x| x.add_properties(:manager_ref => %i(vm_or_template)) }
+    persister.add_collection(:disks) { |x| x.add_properties(:manager_ref => %i(hardware device_name)) }
+    persister.add_collection(:networks) { |x| x.add_properties(:manager_ref => %i(hardware description)) }
+
+    indexed_ics = persister.inventory_collections.index_by(&:name)
+    expect(indexed_ics[:vms_and_templates].parent_inventory_collections).to be_nil
+    expect(indexed_ics[:hardwares].parent_inventory_collections).to be_nil
+    expect(indexed_ics[:disks].parent_inventory_collections).to be_nil
+    expect(indexed_ics[:networks].parent_inventory_collections).to be_nil
+
+    InventoryRefresh::InventoryCollection::Scanner.scan!(persister.inventory_collections)
+
+    # Check parent inventory collections
+    expect(indexed_ics[:vms_and_templates].parent_inventory_collections).to be_nil
+    expect(indexed_ics[:hardwares].parent_inventory_collections).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+    expect(indexed_ics[:disks].parent_inventory_collections).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+    expect(indexed_ics[:networks].parent_inventory_collections).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+
+    # Check dependencies
+    expect(indexed_ics[:vms_and_templates].dependencies).to eq([])
+    expect(indexed_ics[:hardwares].dependencies).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+    expect(indexed_ics[:disks].dependencies).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+    expect(indexed_ics[:networks].dependencies).to(
+      match_array([indexed_ics[:vms_and_templates]])
+    )
+  end
+
+  it "checks parent inventory collections are not overwritten when set as []" do
+    # Add blank presisters
+    persister.add_collection(:vms_and_templates) do |x|
+      x.add_properties(:model_class => VmOrTemplate, :parent_inventory_collections => [])
+    end
+    persister.add_collection(:hardwares) do |x|
+      x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => [])
+    end
+    persister.add_collection(:disks) do |x|
+      x.add_properties(:manager_ref => %i(hardware device_name), :parent_inventory_collections => [])
+    end
+    persister.add_collection(:networks) do |x|
+      x.add_properties(:manager_ref => %i(hardware description), :parent_inventory_collections => [])
+    end
+
+    indexed_ics = persister.inventory_collections.index_by(&:name)
+    expect(indexed_ics[:vms_and_templates].parent_inventory_collections).to eq([])
+    expect(indexed_ics[:hardwares].parent_inventory_collections).to eq([])
+    expect(indexed_ics[:disks].parent_inventory_collections).to eq([])
+    expect(indexed_ics[:networks].parent_inventory_collections).to eq([])
+
+    InventoryRefresh::InventoryCollection::Scanner.scan!(persister.inventory_collections)
+
+    expect(indexed_ics[:vms_and_templates].parent_inventory_collections).to eq([])
+    expect(indexed_ics[:hardwares].parent_inventory_collections).to eq([])
+    expect(indexed_ics[:disks].parent_inventory_collections).to eq([])
+    expect(indexed_ics[:networks].parent_inventory_collections).to eq([])
+  end
+end

--- a/spec/save_inventory/build_parent_inventory_collections_spec.rb
+++ b/spec/save_inventory/build_parent_inventory_collections_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 require_relative '../helpers/spec_parsed_data'
-require_relative '../persister/test_base_persister'
+require_relative '../persister/test_persister'
 
 describe InventoryRefresh::SaveInventory do
   include SpecHelper
@@ -15,21 +15,21 @@ describe InventoryRefresh::SaveInventory do
                               :network_manager => FactoryGirl.create(:ems_network))
   end
 
-  let(:persister_class) { ::TestBasePersister }
+  let(:persister_class) { ::TestPersister }
   let(:persister) { persister_class.new(@ems, @ems) }
 
   it "checks parent inventory collections defined manually are not overwritten" do
     # Add blank presisters
-    persister.add_collection(:vms_and_templates) do |x|
+    persister.add_collection(persister.cloud, :vms_and_templates) do |x|
       x.add_properties(:model_class => VmOrTemplate)
     end
-    persister.add_collection(:hardwares) do |x|
+    persister.add_collection(persister.cloud, :hardwares) do |x|
       x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => %i(vms_and_templates))
     end
-    persister.add_collection(:disks) do |x|
+    persister.add_collection(persister.cloud, :disks) do |x|
       x.add_properties(:manager_ref => %i(hardware device_name), :parent_inventory_collections => %i(vms_and_templates))
     end
-    persister.add_collection(:networks) do |x|
+    persister.add_collection(persister.cloud, :networks) do |x|
       x.add_properties(:manager_ref => %i(hardware description), :parent_inventory_collections => %i(vms_and_templates))
     end
 
@@ -64,10 +64,18 @@ describe InventoryRefresh::SaveInventory do
 
   it "checks parent inventory collections are built correctly based on the model relations" do
     # Add blank presisters
-    persister.add_collection(:vms_and_templates) { |x| x.add_properties(:model_class => VmOrTemplate) }
-    persister.add_collection(:hardwares) { |x| x.add_properties(:manager_ref => %i(vm_or_template)) }
-    persister.add_collection(:disks) { |x| x.add_properties(:manager_ref => %i(hardware device_name)) }
-    persister.add_collection(:networks) { |x| x.add_properties(:manager_ref => %i(hardware description)) }
+    persister.add_collection(persister.cloud, :vms_and_templates) do |x|
+      x.add_properties(:model_class => VmOrTemplate)
+    end
+    persister.add_collection(persister.cloud, :hardwares) do |x|
+      x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => nil)
+    end
+    persister.add_collection(persister.cloud, :disks) do |x|
+      x.add_properties(:manager_ref => %i(hardware device_name), :parent_inventory_collections => nil)
+    end
+    persister.add_collection(persister.cloud, :networks) do |x|
+      x.add_properties(:manager_ref => %i(hardware description), :parent_inventory_collections => nil)
+    end
 
     indexed_ics = persister.inventory_collections.index_by(&:name)
     expect(indexed_ics[:vms_and_templates].parent_inventory_collections).to be_nil
@@ -104,16 +112,16 @@ describe InventoryRefresh::SaveInventory do
 
   it "checks parent inventory collections are not overwritten when set as []" do
     # Add blank presisters
-    persister.add_collection(:vms_and_templates) do |x|
+    persister.add_collection(persister.cloud, :vms_and_templates) do |x|
       x.add_properties(:model_class => VmOrTemplate, :parent_inventory_collections => [])
     end
-    persister.add_collection(:hardwares) do |x|
+    persister.add_collection(persister.cloud, :hardwares) do |x|
       x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => [])
     end
-    persister.add_collection(:disks) do |x|
+    persister.add_collection(persister.cloud, :disks) do |x|
       x.add_properties(:manager_ref => %i(hardware device_name), :parent_inventory_collections => [])
     end
-    persister.add_collection(:networks) do |x|
+    persister.add_collection(persister.cloud, :networks) do |x|
       x.add_properties(:manager_ref => %i(hardware description), :parent_inventory_collections => [])
     end
 
@@ -132,14 +140,12 @@ describe InventoryRefresh::SaveInventory do
   end
 
   it "checks error is thrown for non-existent inventory collection" do
-    persister.add_collection(:hardwares) do |x|
+    persister.add_collection(persister.cloud, :hardwares) do |x|
       x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => %i(random_name))
     end
 
     expect { InventoryRefresh::InventoryCollection::Scanner.scan!(persister.inventory_collections) }.to(
-      raise_exception(
-        "Can't find InventoryCollection :random_name referenced from InventoryCollection:<Hardware>"
-      )
+      raise_error.with_message(/Can't find InventoryCollection :random_name referenced from/)
     )
   end
 end

--- a/spec/save_inventory/build_parent_inventory_collections_spec.rb
+++ b/spec/save_inventory/build_parent_inventory_collections_spec.rb
@@ -130,4 +130,16 @@ describe InventoryRefresh::SaveInventory do
     expect(indexed_ics[:disks].parent_inventory_collections).to eq([])
     expect(indexed_ics[:networks].parent_inventory_collections).to eq([])
   end
+
+  it "checks error is thrown for non-existent inventory collection" do
+    persister.add_collection(:hardwares) do |x|
+      x.add_properties(:manager_ref => %i(vm_or_template), :parent_inventory_collections => %i(random_name))
+    end
+
+    expect { InventoryRefresh::InventoryCollection::Scanner.scan!(persister.inventory_collections) }.to(
+      raise_exception(
+        "Can't find InventoryCollection :random_name referenced from InventoryCollection:<Hardware>"
+      )
+    )
+  end
 end

--- a/spec/save_inventory/graph_of_inventory_collections_spec.rb
+++ b/spec/save_inventory/graph_of_inventory_collections_spec.rb
@@ -286,14 +286,11 @@ describe InventoryRefresh::SaveInventory do
   end
 
   context 'with empty DB' do
-    before do
-      initialize_inventory_collections
-    end
-
     it 'creates and updates a graph of InventoryCollections with cycle stack -> stack' do
       # Doing 2 times, to make sure we first create all records then update all records
       2.times do
         # Fill the InventoryCollections with data
+        initialize_inventory_collections
         init_stack_data_with_stack_stack_cycle
         init_resource_data
 
@@ -309,6 +306,7 @@ describe InventoryRefresh::SaveInventory do
       # Doing 2 times, to make sure we first create all records then update all records
       2.times do
         # Fill the InventoryCollections with data
+        initialize_inventory_collections
         init_stack_data_with_stack_resource_stack_cycle
         init_resource_data
 
@@ -322,14 +320,11 @@ describe InventoryRefresh::SaveInventory do
   end
 
   context 'with empty DB and reversed InventoryCollections' do
-    before do
-      initialize_inventory_collections(:reversed => true)
-    end
-
     it 'creates and updates a graph of InventoryCollections with cycle stack -> stack' do
       # Doing 2 times, to make sure we first create all records then update all records
       2.times do
         # Fill the InventoryCollections with data
+        initialize_inventory_collections(:reversed => true)
         init_stack_data_with_stack_stack_cycle
         init_resource_data
 
@@ -345,6 +340,7 @@ describe InventoryRefresh::SaveInventory do
       # Doing 2 times, to make sure we first create all records then update all records
       2.times do
         # Fill the InventoryCollections with data
+        initialize_inventory_collections(:reversed => true)
         init_stack_data_with_stack_resource_stack_cycle
         init_resource_data
 

--- a/spec/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+++ b/spec/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
@@ -163,8 +163,10 @@ describe InventoryRefresh::SaveInventory do
     initialize_inventory_collections(%i(disks))
 
     @persister.add_collection(:disks) do |builder|
-      builder.add_properties(:parent      => @vm3,
-                             :manager_ref => %i(hardware device_name))
+      builder.add_properties(:parent                       => @vm3,
+                             :manager_ref                  => %i(hardware device_name),
+                             :parent_inventory_collections => []
+      )
     end
 
     @disk_data_3 = disk_data(3).merge(
@@ -230,8 +232,9 @@ describe InventoryRefresh::SaveInventory do
 
     initialize_inventory_collections(%i(disks))
     @persister.add_collection(:disks) do |builder|
-      builder.add_properties(:parent      => @vm3,
-                             :manager_ref => %i(hardware device_name))
+      builder.add_properties(:parent                       => @vm3,
+                             :manager_ref                  => %i(hardware device_name),
+                             :parent_inventory_collections => [])
     end
     @disk_data_3 = disk_data(3).merge(
       :hardware => @persister.hardwares.lazy_find(@persister.vms.lazy_find(vm_data(3)[:ems_ref]))
@@ -313,13 +316,15 @@ describe InventoryRefresh::SaveInventory do
     )
 
     hardwares_init_data(
-      :arel        => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
-      :strategy    => :local_db_find_missing_references,
-      :manager_ref => %i(vm_or_template)
+      :arel                         => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
+      :strategy                     => :local_db_find_missing_references,
+      :manager_ref                  => %i(vm_or_template),
+      :parent_inventory_collections => %i(vms)
     )
 
     disks_init_data(
-      :arel => @ems.disks.joins(:hardware => :vm_or_template).where('hardware' => {'vms' => {'ems_ref' => vm_refs}}),
+      :arel                         => @ems.disks.joins(:hardware => :vm_or_template).where('hardware' => {'vms' => {'ems_ref' => vm_refs}}),
+      :parent_inventory_collections => %i(vms)
     )
 
     @vm_data_3 = vm_data(3).merge(

--- a/spec/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+++ b/spec/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
@@ -163,9 +163,10 @@ describe InventoryRefresh::SaveInventory do
     initialize_inventory_collections(%i(disks))
 
     @persister.add_collection(:disks) do |builder|
-      builder.add_properties(:parent                       => @vm3,
-                             :manager_ref                  => %i(hardware device_name),
-                             :parent_inventory_collections => []
+      builder.add_properties(
+        :parent                       => @vm3,
+        :manager_ref                  => %i(hardware device_name),
+        :parent_inventory_collections => []
       )
     end
 

--- a/spec/save_inventory/strategies_and_references_spec.rb
+++ b/spec/save_inventory/strategies_and_references_spec.rb
@@ -153,8 +153,9 @@ describe InventoryRefresh::SaveInventory do
           :strategy => :local_db_find_missing_references
         )
         hardwares_init_data(
-          :arel     => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
-          :strategy => db_strategy
+          :arel                         => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
+          :strategy                     => db_strategy,
+          :parent_inventory_collections => %i(vms)
         )
 
         # Parse data for InventoryCollections
@@ -241,8 +242,9 @@ describe InventoryRefresh::SaveInventory do
           :strategy => :local_db_find_missing_references,
         )
         hardwares_init_data(
-          :arel     => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
-          :strategy => :local_db_find_missing_references
+          :arel                         => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
+          :strategy                     => :local_db_find_missing_references,
+          :parent_inventory_collections => %i(vms)
         )
         network_ports_init_data(
           :parent   => @ems.network_manager,


### PR DESCRIPTION
We can infer parent inventory collections automatically, in some cases. For current specs, we nee to define some manually, because e.g. hardware is relation through :vms_and_templates, but such IC is not define for cloud.

Depends on:

- [x] https://github.com/ManageIQ/inventory_refresh/pull/19
- [x] https://github.com/ManageIQ/manageiq/pull/18048