### PR TITLE
Gemfile.dev support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,11 @@
 
 /Gemfile.lock
 
+# ignore included plugins in bundler.d
+bundler.d/*
+
 # rspec failure tracking
 .rspec_status
+
+# generated rubocop file
+.rubocop-https*

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in inventory_refresh.gemspec
 gemspec
+
+# Load other additional Gemfiles
+#   Developers can create a file ending in .rb under bundler.d/ to specify additional development dependencies
+Dir.glob(File.join(__dir__, 'bundler.d/*.rb')).each { |f| eval_gemfile(File.expand_path(f, __dir__)) }


### PR DESCRIPTION
.. and rubocop file ignoring

Gemfile.dev.rb can be added for dev purposes under bundler.d folder (like in ManageIQ)