### PR TITLE
Replace ampersand with try in persister's add_collection

### DIFF
--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -41,7 +41,7 @@ module InventoryRefresh
 
       builder.add_properties(extra_properties) if extra_properties.present?
 
-      builder.add_properties({:manager_uuids => target&.references(collection_name) || []}, :if_missing) if targeted?
+      builder.add_properties({:manager_uuids => target.try(:references, collection_name) || []}, :if_missing) if targeted?
 
       builder.evaluate_lambdas!(self)
 


### PR DESCRIPTION
Fixing ampersand, which doesn't eat non-existing methods.

@miq-bot add_label bug

cc @agrare