### PR TITLE
Add a .from_hash method to Persister

### DIFF
--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -106,6 +106,21 @@ module InventoryRefresh
       JSON.dump(to_hash)
     end
 
+    class << self
+      def from_hash(manager, hash, target = nil)
+        target ||= InventoryRefresh::TargetCollection.new(:manager => manager)
+        new(manager, target).tap do |persister|
+          Array(hash["collections"]).each do |collection_hash|
+            collection_name = collection_hash["name"]
+            inventory_collection = persister.collections[collection_name&.to_sym]
+            next if inventory_collection.nil?
+
+            inventory_collection.from_hash(collection_hash, persister.collections)
+          end
+        end
+      end
+    end
+
     protected
 
     def initialize_inventory_collections

--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -92,30 +92,51 @@ module InventoryRefresh
       InventoryRefresh::SaveInventory.save_inventory(manager, inventory_collections)
     end
 
-    # Returns Persister object loaded from a passed JSON
-    #
-    # @param json_data [String] input JSON data
-    # @return [ManageIQ::Providers::Inventory::Persister] Persister object loaded from a passed JSON
-    def self.from_json(json_data)
-      from_hash(JSON.parse(json_data))
-    end
-
     # Returns serialized Persisted object to JSON
     # @return [String] serialized Persisted object to JSON
     def to_json
       JSON.dump(to_hash)
     end
 
-    class << self
-      def from_hash(manager, hash, target = nil)
-        target ||= InventoryRefresh::TargetCollection.new(:manager => manager)
-        new(manager, target).tap do |persister|
-          Array(hash["collections"]).each do |collection_hash|
-            collection_name = collection_hash["name"]
-            inventory_collection = persister.collections[collection_name&.to_sym]
-            next if inventory_collection.nil?
+    # @return [Hash] entire Persister object serialized to hash
+    def to_hash
+      collections_data = collections.map do |_, collection|
+        next if collection.data.blank?                              &&
+                collection.targeted_scope.primary_references.blank? &&
+                collection.all_manager_uuids.nil?                   &&
+                collection.skeletal_primary_index.index_data.blank?
 
-            inventory_collection.from_hash(collection_hash, persister.collections)
+        collection.to_hash
+      end.compact
+
+      {
+        :collections => collections_data
+      }
+    end
+
+    class << self
+      # Returns Persister object loaded from a passed JSON
+      #
+      # @param json_data [String] input JSON data
+      # @return [ManageIQ::Providers::Inventory::Persister] Persister object loaded from a passed JSON
+      def from_json(json_data, manager, target = nil)
+        from_hash(JSON.parse(json_data), manager, target)
+      end
+
+      # Returns Persister object built from serialized data
+      #
+      # @param persister_data [Hash] serialized Persister object in hash
+      # @return [ManageIQ::Providers::Inventory::Persister] Persister object built from serialized data
+      def from_hash(persister_data, manager, target = nil)
+        # TODO(lsmola) we need to pass serialized targeted scope here
+        target ||= InventoryRefresh::TargetCollection.new(:manager => manager)
+
+        new(manager, target).tap do |persister|
+          persister_data['collections'].each do |collection|
+            inventory_collection = persister.collections[collection['name'].try(:to_sym)]
+            raise "Unrecognized InventoryCollection name: #{inventory_collection}" if inventory_collection.blank?
+
+            inventory_collection.from_hash(collection, persister.collections)
           end
         end
       end

--- a/spec/helpers/test_persister.rb
+++ b/spec/helpers/test_persister.rb
@@ -6,63 +6,8 @@ class TestPersister < InventoryRefresh::Persister
 
   include ::TestBuilder::PersisterHelper
 
-  # @param _manager [ManageIQ::Providers::BaseManager] A manager object
-  # @param _target [Object] A refresh Target object
-  def initialize(_manager, _target = nil)
-    super
-  end
-
   # @return [Config::Options] Options for the manager type
   def options
     @options ||= {}
-  end
-
-  # @return [Hash] entire Persister object serialized to hash
-  def to_hash
-    collections_data = collections.map do |_, collection|
-      next if collection.data.blank?                              &&
-              collection.targeted_scope.primary_references.blank? &&
-              collection.all_manager_uuids.nil?                   &&
-              collection.skeletal_primary_index.index_data.blank?
-
-      collection.to_hash
-    end.compact
-
-    {
-      :ems_id      => manager.id,
-      :class       => self.class.name,
-      :collections => collections_data
-    }
-  end
-
-  class << self
-    protected
-
-    # Returns Persister object built from serialized data
-    #
-    # @param persister_data [Hash] serialized Persister object in hash
-    # @return [ManageIQ::Providers::Inventory::Persister] Persister object built from serialized data
-    def from_hash(persister_data)
-      # Extract the specific Persister class
-      persister_class = persister_data['class'].constantize
-      unless persister_class < InventoryRefresh::Persister
-        raise "Persister class must inherit from a InventoryRefresh::Persister"
-      end
-
-      # TODO(mslemr) Due to this find is persister connected ManageIQ class!
-      ems = ManageIQ::Providers::BaseManager.find(persister_data['ems_id'])
-      persister = persister_class.new(
-        ems,
-        InventoryRefresh::TargetCollection.new(:manager => ems) # TODO(lsmola) we need to pass serialized targeted scope here
-      )
-
-      persister_data['collections'].each do |collection|
-        inventory_collection = persister.collections[collection['name'].try(:to_sym)]
-        raise "Unrecognized InventoryCollection name: #{inventory_collection}" if inventory_collection.blank?
-
-        inventory_collection.from_hash(collection, persister.collections)
-      end
-      persister
-    end
   end
 end

--- a/spec/persister/serializing_spec.rb
+++ b/spec/persister/serializing_spec.rb
@@ -18,7 +18,7 @@ describe InventoryRefresh::Persister do
     persister = create_persister
     populate_test_data(persister)
 
-    ::TestPersister.from_json(persister.to_json).persist!
+    TestPersister::Cloud.from_json(persister.to_json, @ems).persist!
 
     counts = {
       :disk           => 2,

--- a/spec/persister/test_collector.rb
+++ b/spec/persister/test_collector.rb
@@ -68,7 +68,8 @@ class TestCollector
     end
 
     def refresh(persister)
-      persister = persister.class.from_json(persister.to_json)
+      manager = persister.manager
+      persister = persister.class.from_json(persister.to_json, manager)
       persister.persist!
       persister
     end


### PR DESCRIPTION
Add a class method to build a persister from a hash

@Ladas I prefer this method over passing the type in the json and having the .from_hash do the constantize because it allows the caller (i.e. the backend persister) to build the class and constantize it over the builder of the json payload (i.e. the collector) from having to know the full class name.

This lets me have the collector reference the persister by name (i.e. "Default") rather than by a full class name which should be internal knowledge.