### PR TITLE
Relax version requirements on rails/pg gems

### DIFF
--- a/inventory_refresh.gemspec
+++ b/inventory_refresh.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 5.0.6"
+  spec.add_dependency "activerecord", ">= 5.0.0.racecar1", "< 5.2"
   spec.add_dependency "more_core_extensions", "~> 3.5"
-  spec.add_dependency "pg", "~> 0.18.2"
+  spec.add_dependency "pg", "> 0"
 
   spec.add_development_dependency "ancestry"
   spec.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
These requirements were pulled from MIQ but should be relaxed to allow
for other apps to use newer versions of rails/pg.