### PR TITLE
Skip processing of noop earlier

### DIFF
--- a/lib/inventory_refresh/save_collection/base.rb
+++ b/lib/inventory_refresh/save_collection/base.rb
@@ -36,7 +36,7 @@ module InventoryRefresh::SaveCollection
       # @return [Boolean] True if processing of the collection should be skipped
       def skip?(inventory_collection)
         if inventory_collection.noop?
-          logger.debug("Skipping #{inventory_collection} because it results to noop.")
+          logger.debug("Skipping #{inventory_collection} processing because it will do no operation.")
           inventory_collection.saved = true
           return true
         end


### PR DESCRIPTION
Skip processing of noop earlier so it's faster and more clear in
a log. Also add visual helper to help see individual saves in the
log.