### PR TITLE
Fix creating complement_of! query for single manager_uuid

### DIFF
--- a/lib/inventory_refresh/save_collection/saver/sql_helper.rb
+++ b/lib/inventory_refresh/save_collection/saver/sql_helper.rb
@@ -139,15 +139,12 @@ module InventoryRefresh::SaveCollection
         first_value = manager_uuids.shift.to_h
         first_value = "(#{all_attribute_keys_array.map { |x| quote(connection, first_value[x], x, true) }.join(",")})"
 
-        if manager_uuids.blank?
-          values = first_value
-        else
-          # Rest of the values, without the type cast
-          values = manager_uuids.map! do |hash|
-            "(#{all_attribute_keys_array.map { |x| quote(connection, hash[x], x, false) }.join(",")})"
-          end.join(",")
-          values = [first_value, values].join(",")
-        end
+        # Rest of the values, without the type cast
+        values = manager_uuids.map! do |hash|
+          "(#{all_attribute_keys_array.map { |x| quote(connection, hash[x], x, false) }.join(",")})"
+        end.join(",")
+
+        values = values.blank? ? first_value : [first_value, values].join(",")
 
         <<-SQL
           SELECT *

--- a/lib/inventory_refresh/save_collection/saver/sql_helper.rb
+++ b/lib/inventory_refresh/save_collection/saver/sql_helper.rb
@@ -138,11 +138,17 @@ module InventoryRefresh::SaveCollection
         # For Postgre, only first set of values should contain the type casts
         first_value = manager_uuids.shift.to_h
         first_value = "(#{all_attribute_keys_array.map { |x| quote(connection, first_value[x], x, true) }.join(",")})"
-        # Rest of the values, without the type cast
-        values = manager_uuids.map! do |hash|
-          "(#{all_attribute_keys_array.map { |x| quote(connection, hash[x], x, false) }.join(",")})"
-        end.join(",")
-        values = [first_value, values].join(",")
+
+        if manager_uuids.blank?
+          values = first_value
+        else
+          # Rest of the values, without the type cast
+          values = manager_uuids.map! do |hash|
+            "(#{all_attribute_keys_array.map { |x| quote(connection, hash[x], x, false) }.join(",")})"
+          end.join(",")
+          values = [first_value, values].join(",")
+        end
+
         <<-SQL
           SELECT *
           FROM   (VALUES #{values}) AS active_entities_table(#{all_attribute_keys_array_q.join(",")})


### PR DESCRIPTION
With one manager_uuid it created query like this:

`SELECT *  FROM   (VALUES ('node-uuid'),) AS active_entities_table('source_ref')`
(unwanted comma after VALUES)

cc @agrare @Ladas 