### PR TITLE
Use resource version to optimize saving

### DIFF
--- a/lib/inventory_refresh/inventory_collection.rb
+++ b/lib/inventory_refresh/inventory_collection.rb
@@ -264,12 +264,13 @@ module InventoryRefresh
 
       @internal_columns = [] + internal_timestamp_columns
       @internal_columns << :type if supports_sti?
-      @internal_columns += %i(resource_timestamps_max
-                              resource_timestamps
-                              resource_timestamp
-                              resource_counters_max
-                              resource_counters
-                              resource_counter).collect do |col|
+      @internal_columns += [resource_version_column,
+                            :resource_timestamps_max,
+                            :resource_timestamps,
+                            :resource_timestamp,
+                            :resource_counters_max,
+                            :resource_counters,
+                            :resource_counter].collect do |col|
         col if supports_column?(col)
       end.compact
     end

--- a/lib/inventory_refresh/inventory_collection.rb
+++ b/lib/inventory_refresh/inventory_collection.rb
@@ -255,6 +255,10 @@ module InventoryRefresh
       uniq_key_candidates
     end
 
+    def resource_version_column
+      :resource_version
+    end
+
     def internal_columns
       return @internal_columns if @internal_columns
 

--- a/lib/inventory_refresh/save_collection/saver/base.rb
+++ b/lib/inventory_refresh/save_collection/saver/base.rb
@@ -24,7 +24,7 @@ module InventoryRefresh::SaveCollection
         @arel_primary_key       = @model_class.arel_attribute(@primary_key)
         @unique_index_keys      = inventory_collection.unique_index_keys
         @unique_index_keys_to_s = inventory_collection.manager_ref_to_cols.map(&:to_s)
-        @select_keys            = [@primary_key] + @unique_index_keys_to_s
+        @select_keys            = [@primary_key] + @unique_index_keys_to_s + internal_select_keys
         @unique_db_primary_keys = Set.new
         @unique_db_indexes      = Set.new
 
@@ -73,6 +73,18 @@ module InventoryRefresh::SaveCollection
         end
       end
 
+      def internal_select_keys
+        inventory_collection.internal_timestamp_columns + [resource_version_column,
+                                                           :resource_timestamps_max,
+                                                           :resource_timestamps,
+                                                           :resource_timestamp,
+                                                           :resource_counters_max,
+                                                           :resource_counters,
+                                                           :resource_counter].collect do |col|
+          col if inventory_collection.supports_column?(col)
+        end.compact.map(&:to_s)
+      end
+
       # Saves the InventoryCollection
       def save_inventory_collection!
         # If we have a targeted InventoryCollection that wouldn't do anything, quickly skip it
@@ -89,7 +101,7 @@ module InventoryRefresh::SaveCollection
 
       attr_reader :inventory_collection, :association
 
-      delegate :build_stringified_reference, :build_stringified_reference_for_record, :to => :inventory_collection
+      delegate :build_stringified_reference, :build_stringified_reference_for_record, :resource_version_column, :to => :inventory_collection
 
       # Applies serialize method for each relevant attribute, which will cast the value to the right type.
       #
@@ -331,14 +343,20 @@ module InventoryRefresh::SaveCollection
         @serializable_keys_bool_cache ||= serializable_keys.present?
       end
 
-      # @return [Boolean] true if the model_class has resource_timestamp column
+      # @return [Boolean] true if the keys we are saving have resource_timestamp column
       def supports_remote_data_timestamp?(all_attribute_keys)
         all_attribute_keys.include?(:resource_timestamp) # include? on Set is O(1)
       end
 
-      # @return [Boolean] true if the model_class has resource_counter column
+      # @return [Boolean] true if the keys we are saving have resource_counter column
       def supports_remote_data_version?(all_attribute_keys)
         all_attribute_keys.include?(:resource_counter) # include? on Set is O(1)
+      end
+
+      # @return [Boolean] true if the keys we are saving have resource_version column, which solves for a quick check
+      #                   if the record was modified
+      def supports_resource_version?(all_attribute_keys)
+        all_attribute_keys.include?(resource_version_column) # include? on Set is O(1)
       end
     end
   end

--- a/lib/inventory_refresh/save_collection/saver/base.rb
+++ b/lib/inventory_refresh/save_collection/saver/base.rb
@@ -24,7 +24,7 @@ module InventoryRefresh::SaveCollection
         @arel_primary_key       = @model_class.arel_attribute(@primary_key)
         @unique_index_keys      = inventory_collection.unique_index_keys
         @unique_index_keys_to_s = inventory_collection.manager_ref_to_cols.map(&:to_s)
-        @select_keys            = [@primary_key] + @unique_index_keys_to_s + internal_select_keys
+        @select_keys            = [@primary_key] + @unique_index_keys_to_s + internal_columns.map(&:to_s)
         @unique_db_primary_keys = Set.new
         @unique_db_indexes      = Set.new
 
@@ -73,18 +73,6 @@ module InventoryRefresh::SaveCollection
         end
       end
 
-      def internal_select_keys
-        inventory_collection.internal_timestamp_columns + [resource_version_column,
-                                                           :resource_timestamps_max,
-                                                           :resource_timestamps,
-                                                           :resource_timestamp,
-                                                           :resource_counters_max,
-                                                           :resource_counters,
-                                                           :resource_counter].collect do |col|
-          col if inventory_collection.supports_column?(col)
-        end.compact.map(&:to_s)
-      end
-
       # Saves the InventoryCollection
       def save_inventory_collection!
         # If we have a targeted InventoryCollection that wouldn't do anything, quickly skip it
@@ -101,7 +89,11 @@ module InventoryRefresh::SaveCollection
 
       attr_reader :inventory_collection, :association
 
-      delegate :build_stringified_reference, :build_stringified_reference_for_record, :resource_version_column, :to => :inventory_collection
+      delegate :build_stringified_reference,
+               :build_stringified_reference_for_record,
+               :resource_version_column,
+               :internal_columns,
+               :to => :inventory_collection
 
       # Applies serialize method for each relevant attribute, which will cast the value to the right type.
       #

--- a/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -356,6 +356,9 @@ module InventoryRefresh::SaveCollection
         hashes                    = []
         create_time               = time_now
 
+        # We cannot set the resource_version doing partial update
+        all_attribute_keys -= [resource_version_column]
+
         skeletal_inventory_objects_index.each do |index, inventory_object|
           hash = skeletal_attributes_index.delete(index)
           # Partial create or update must never set a timestamp for the whole row

--- a/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -184,9 +184,9 @@ module InventoryRefresh::SaveCollection
                                                    [:resource_counter, :resource_counters_max]
                                                  end
 
-                next if skeletonize_or_skip_record(record.try(version_attr) || record.try(:[], version_attr),
+                next if skeletonize_or_skip_record(record_key(record, version_attr),
                                                    hash[version_attr],
-                                                   record.try(max_version_attr) || record.try(:[], max_version_attr),
+                                                   record_key(record, max_version_attr),
                                                    inventory_object)
               end
 

--- a/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -171,9 +171,9 @@ module InventoryRefresh::SaveCollection
               end
             else
               # Record was found in the DB and sent for saving, we will be updating the DB.
+              inventory_object.id = primary_key_value
               next unless assert_referential_integrity(hash)
               next unless changed?(record, hash, all_attribute_keys)
-              inventory_object.id = primary_key_value
 
               if inventory_collection.parallel_safe? &&
                  (supports_remote_data_timestamp?(all_attribute_keys) || supports_remote_data_version?(all_attribute_keys))

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -599,6 +599,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.integer  "resource_counter"
     t.jsonb    "resource_counters", default: {}
     t.integer  "resource_counters_max"
+    t.string   "resource_version"
     t.index ["archived_on"], name: "index_container_groups_on_archived_on", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_container_groups_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["ems_id"], name: "index_container_groups_on_ems_id", using: :btree


### PR DESCRIPTION
Use resource version to optimize saving, if resource_version is present, we will use it for equality checks and we'll not update records having the same resource_version. That way we'll speed up the second+ refresh