### PR TITLE
Add all manager uuids scope

### DIFF
--- a/lib/inventory_refresh/inventory_collection.rb
+++ b/lib/inventory_refresh/inventory_collection.rb
@@ -78,6 +78,9 @@ module InventoryRefresh
     # @return [Array, nil] nil or a list of all :manager_uuids that are present in the Provider's InventoryCollection.
     attr_accessor :all_manager_uuids
 
+    # @return [Array, nil] Scope for applying :all_manager_uuids
+    attr_accessor :all_manager_uuids_scope
+
     # @return [Set] A set of InventoryCollection objects that depends on this InventoryCollection object.
     attr_accessor :dependees
 
@@ -156,7 +159,8 @@ module InventoryRefresh
                       properties[:manager_ref_allowed_nil],
                       properties[:secondary_refs],
                       properties[:manager_uuids],
-                      properties[:all_manager_uuids])
+                      properties[:all_manager_uuids],
+                      properties[:all_manager_uuids_scope])
 
       init_ic_relations(properties[:dependency_attributes],
                         properties[:parent_inventory_collections])

--- a/lib/inventory_refresh/inventory_collection.rb
+++ b/lib/inventory_refresh/inventory_collection.rb
@@ -158,9 +158,10 @@ module InventoryRefresh
       init_references(properties[:manager_ref],
                       properties[:manager_ref_allowed_nil],
                       properties[:secondary_refs],
-                      properties[:manager_uuids],
-                      properties[:all_manager_uuids],
-                      properties[:all_manager_uuids_scope])
+                      properties[:manager_uuids])
+
+      init_all_manager_uuids(properties[:all_manager_uuids],
+                             properties[:all_manager_uuids_scope])
 
       init_ic_relations(properties[:dependency_attributes],
                         properties[:parent_inventory_collections])

--- a/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
+++ b/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
@@ -71,6 +71,13 @@ module InventoryRefresh
         #        this attribute, the db_collection_for_comparison will be automatically limited by the manager_uuids, in a
         #        case of a simple relation. In a case of a complex relation, we can leverage :manager_uuids in a
         #        custom :targeted_arel. We can pass also lambda, for lazy_evaluation.
+        def init_references(manager_ref, manager_ref_allowed_nil, secondary_refs,  manager_uuids)
+          @manager_ref             = manager_ref || %i(ems_ref)
+          @manager_ref_allowed_nil = manager_ref_allowed_nil || []
+          @secondary_refs          = secondary_refs || {}
+          @manager_uuids           = manager_uuids || []
+        end
+
         # @param all_manager_uuids [Array] Array of all manager_uuids of the InventoryObjects. With the :targeted true,
         #        having this parameter defined will invoke only :delete_method on a complement of this set, making sure
         #        the DB has only this set of data after. This :attribute serves for deleting of top level
@@ -89,13 +96,7 @@ module InventoryRefresh
         #
         #        Will cause deletion/archival or all entities that don't have source_ref "x" or "y", but only under
         #        regions X and Y.
-        def init_references(manager_ref, manager_ref_allowed_nil, secondary_refs,
-                            manager_uuids, all_manager_uuids, all_manager_uuids_scope)
-          @manager_ref             = manager_ref || %i(ems_ref)
-          @manager_ref_allowed_nil = manager_ref_allowed_nil || []
-          @secondary_refs          = secondary_refs || {}
-          @manager_uuids           = manager_uuids || []
-          # Targeted mode related attributes
+        def init_all_manager_uuids(all_manager_uuids, all_manager_uuids_scope)
           # TODO(lsmola) Should we refactor this to use references too?
           @all_manager_uuids       = all_manager_uuids
           @all_manager_uuids_scope = all_manager_uuids_scope

--- a/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
+++ b/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
@@ -83,18 +83,12 @@ module InventoryRefresh
         #        If all_manager_uuids_scope is used with :all_manager_uuids => nil, it will do delete_complement of the
         #        scope itself. E.g. sending a list of all active regions, we will delete complement entities not
         #        belonging to those regions.
-        #        Example 1:
+        #        Example:
         #          :all_manager_uuids       => [{:source_ref => x}, {:source_ref => y}],
         #          :all_manager_uuids_scope => [{:region => regions.lazy_find(X)}, {:region => regions.lazy_find(Y)}]
         #
         #        Will cause deletion/archival or all entities that don't have source_ref "x" or "y", but only under
         #        regions X and Y.
-        #
-        #        Example 2:
-        #          :all_manager_uuids       => nil # nil is the default value
-        #          :all_manager_uuids_scope => [{:region => regions.lazy_find(X)}, {:region => regions.lazy_find(Y)}]
-        #
-        #        Will cause deletion/archival or all entities that are not in region X or Y
         def init_references(manager_ref, manager_ref_allowed_nil, secondary_refs,
                             manager_uuids, all_manager_uuids, all_manager_uuids_scope)
           @manager_ref             = manager_ref || %i(ems_ref)

--- a/lib/inventory_refresh/save_collection/saver/retention_helper.rb
+++ b/lib/inventory_refresh/save_collection/saver/retention_helper.rb
@@ -12,7 +12,7 @@ module InventoryRefresh::SaveCollection
         logger.debug("Processing :delete_complement of #{inventory_collection} of size "\
                      "#{all_manager_uuids_size}...")
 
-        query = complement_of!(inventory_collection.all_manager_uuids)
+        query = complement_of!(inventory_collection.all_manager_uuids, inventory_collection.all_manager_uuids_scope)
 
         ids_of_non_active_entities = ActiveRecord::Base.connection.execute(query.to_sql).to_a
         ids_of_non_active_entities.each_slice(10_000) do |batch|

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-factory :orchestration_stack do
+  factory :orchestration_stack do
     ems_ref "1"
   end
 

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :orchestration_stack do
+factory :orchestration_stack do
     ems_ref "1"
   end
 

--- a/spec/factories/source_region.rb
+++ b/spec/factories/source_region.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :source_region
+end

--- a/spec/factories/subscription.rb
+++ b/spec/factories/subscription.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :subscription
+end

--- a/spec/helpers/test_builder/shared.rb
+++ b/spec/helpers/test_builder/shared.rb
@@ -77,6 +77,14 @@ class TestBuilder
         )
       end
 
+      def source_regions
+        add_common_default_values
+      end
+
+      def subscriptions
+        add_common_default_values
+      end
+
       protected
 
       def add_common_default_values

--- a/spec/helpers/test_persister/cloud.rb
+++ b/spec/helpers/test_persister/cloud.rb
@@ -15,7 +15,9 @@ class TestPersister::Cloud < ::TestPersister
     add_key_pairs
     add_flavors
 
-    %i(hardwares
+    %i(source_regions
+       subscriptions
+       hardwares
        networks
        disks
        orchestration_stacks).each do |name|

--- a/spec/models/ext_management_system.rb
+++ b/spec/models/ext_management_system.rb
@@ -8,4 +8,7 @@ class ExtManagementSystem < ::ActiveRecord::Base
   has_many :hardwares,         :through => :vms_and_templates
   has_many :disks,             :through => :hardwares
   has_many :networks,          :through => :hardwares
+
+  has_many :source_regions, :foreign_key => :ems_id
+  has_many :subscriptions, :foreign_key => :ems_id
 end

--- a/spec/models/source_region.rb
+++ b/spec/models/source_region.rb
@@ -1,0 +1,8 @@
+require_relative 'archived_mixin'
+
+class SourceRegion < ActiveRecord::Base
+  include ArchivedMixin
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id
+  has_many :vms
+end

--- a/spec/models/subscription.rb
+++ b/spec/models/subscription.rb
@@ -1,0 +1,8 @@
+require_relative 'archived_mixin'
+
+class Subscription < ActiveRecord::Base
+  include ArchivedMixin
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id
+  has_many :vms
+end

--- a/spec/models/vm_or_template.rb
+++ b/spec/models/vm_or_template.rb
@@ -7,6 +7,8 @@ class VmOrTemplate < ActiveRecord::Base
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
   belongs_to :flavor
+  belongs_to :source_region
+  belongs_to :subscription
 
   has_one :hardware, :dependent => :destroy
   has_many :disks, :through => :hardware

--- a/spec/persister/retention_strategies_spec.rb
+++ b/spec/persister/retention_strategies_spec.rb
@@ -67,47 +67,47 @@ describe InventoryRefresh::Persister do
           region2 = FactoryGirl.create(:source_region, :ems_ref => "region2", :ext_management_system => @ems)
           region3 = FactoryGirl.create(:source_region, :ems_ref => "region3", :ext_management_system => @ems)
 
-          vm1 = FactoryGirl.create(:vm_cloud,
-                                   vm_data(1).merge(
-                                     :ext_management_system => @ems,
-                                     :subscription          => subscription1,
-                                     :source_region         => region1,
-                                   )
+          vm1  = FactoryGirl.create(:vm_cloud,
+                                    vm_data(1).merge(
+                                      :ext_management_system => @ems,
+                                      :subscription          => subscription1,
+                                      :source_region         => region1,
+                                    )
           )
-          vm2 = FactoryGirl.create(:vm_cloud,
-                                   vm_data(2).merge(
-                                     :ext_management_system => @ems,
-                                     :subscription          => subscription2,
-                                     :source_region         => region2,
-                                   )
+          _vm2 = FactoryGirl.create(:vm_cloud,
+                                    vm_data(2).merge(
+                                      :ext_management_system => @ems,
+                                      :subscription          => subscription2,
+                                      :source_region         => region2,
+                                    )
           )
-          vm3 = FactoryGirl.create(:vm_cloud,
-                                   vm_data(3).merge(
-                                     :ext_management_system => @ems,
-                                     :subscription          => subscription2,
-                                     :source_region         => region3,
-                                   )
+          _vm3 = FactoryGirl.create(:vm_cloud,
+                                    vm_data(3).merge(
+                                      :ext_management_system => @ems,
+                                      :subscription          => subscription2,
+                                      :source_region         => region3,
+                                    )
           )
-          vm4 = FactoryGirl.create(:vm_cloud,
-                                   vm_data(4).merge(
-                                     :ext_management_system => @ems,
-                                     :subscription          => subscription2,
-                                     :source_region         => region1,
-                                   )
+          _vm4 = FactoryGirl.create(:vm_cloud,
+                                    vm_data(4).merge(
+                                      :ext_management_system => @ems,
+                                      :subscription          => subscription2,
+                                      :source_region         => region1,
+                                    )
           )
-          vm5 = FactoryGirl.create(:vm_cloud,
-                                   vm_data(5).merge(
-                                     :ext_management_system => @ems,
-                                     :subscription          => subscription1,
-                                     :source_region         => region2,
-                                   )
+          _vm5 = FactoryGirl.create(:vm_cloud,
+                                    vm_data(5).merge(
+                                      :ext_management_system => @ems,
+                                      :subscription          => subscription1,
+                                      :source_region         => region2,
+                                    )
           )
-          vm6 = FactoryGirl.create(:vm_cloud,
-                                   vm_data(6).merge(
-                                     :ext_management_system => @ems,
-                                     :subscription          => subscription1,
-                                     :source_region         => region1,
-                                   )
+          _vm6 = FactoryGirl.create(:vm_cloud,
+                                    vm_data(6).merge(
+                                      :ext_management_system => @ems,
+                                      :subscription          => subscription1,
+                                      :source_region         => region1,
+                                    )
           )
 
 
@@ -140,7 +140,7 @@ describe InventoryRefresh::Persister do
         it "fails if all_manager_uuids_scope is using wrong relation" do
           persister = create_persister(extra_options.merge(:retention_strategy => "archive"))
 
-          persister.vms.all_manager_uuids = []
+          persister.vms.all_manager_uuids       = []
           persister.vms.all_manager_uuids_scope = [
             {:non_existent_relation => persister.source_regions.lazy_find("region1"), :subscription => persister.subscriptions.lazy_find("subscription1")},
             {:non_existent_relation => persister.source_regions.lazy_find("region2"), :subscription => persister.subscriptions.lazy_find("subscription1")}
@@ -154,7 +154,7 @@ describe InventoryRefresh::Persister do
         it "fails if all_manager_uuids_scope is pointing to the wrong value" do
           persister = create_persister(extra_options.merge(:retention_strategy => "archive"))
 
-          persister.vms.all_manager_uuids = []
+          persister.vms.all_manager_uuids       = []
           persister.vms.all_manager_uuids_scope = [
             {:source_region => persister.source_regions.lazy_find("region1_fake", :key => :name), :subscription => persister.subscriptions.lazy_find("subscription1")},
             {:source_region => persister.source_regions.lazy_find("region2"), :subscription => persister.subscriptions.lazy_find("subscription1")}
@@ -169,11 +169,11 @@ describe InventoryRefresh::Persister do
         end
 
         it "fails if all_manager_uuids_scope have inconsistent keys" do
-          region1 = FactoryGirl.create(:source_region, :ems_ref => "region1", :ext_management_system => @ems)
+          _region1 = FactoryGirl.create(:source_region, :ems_ref => "region1", :ext_management_system => @ems)
 
           persister = create_persister(extra_options.merge(:retention_strategy => "archive"))
 
-          persister.vms.all_manager_uuids = []
+          persister.vms.all_manager_uuids       = []
           persister.vms.all_manager_uuids_scope = [
             {:source_region => persister.source_regions.lazy_find("region1")},
             {:source_region => persister.source_regions.lazy_find("region2"), :subscription => persister.subscriptions.lazy_find("subscription1")}

--- a/spec/persister/retention_strategies_spec.rb
+++ b/spec/persister/retention_strategies_spec.rb
@@ -55,6 +55,138 @@ describe InventoryRefresh::Persister do
         end
       end
 
+      context "with :all_manager_uuids_scope" do
+        it "archives the data with :retention_strategy => 'archive'" do
+          Vm.destroy_all
+          persister = create_persister(extra_options.merge(:retention_strategy => "archive"))
+
+          subscription1 = FactoryGirl.create(:subscription, :ems_ref => "subscription1", :ext_management_system => @ems)
+          subscription2 = FactoryGirl.create(:subscription, :ems_ref => "subscription2", :ext_management_system => @ems)
+
+          region1 = FactoryGirl.create(:source_region, :ems_ref => "region1", :ext_management_system => @ems)
+          region2 = FactoryGirl.create(:source_region, :ems_ref => "region2", :ext_management_system => @ems)
+          region3 = FactoryGirl.create(:source_region, :ems_ref => "region3", :ext_management_system => @ems)
+
+          vm1 = FactoryGirl.create(:vm_cloud,
+                                   vm_data(1).merge(
+                                     :ext_management_system => @ems,
+                                     :subscription          => subscription1,
+                                     :source_region         => region1,
+                                   )
+          )
+          vm2 = FactoryGirl.create(:vm_cloud,
+                                   vm_data(2).merge(
+                                     :ext_management_system => @ems,
+                                     :subscription          => subscription2,
+                                     :source_region         => region2,
+                                   )
+          )
+          vm3 = FactoryGirl.create(:vm_cloud,
+                                   vm_data(3).merge(
+                                     :ext_management_system => @ems,
+                                     :subscription          => subscription2,
+                                     :source_region         => region3,
+                                   )
+          )
+          vm4 = FactoryGirl.create(:vm_cloud,
+                                   vm_data(4).merge(
+                                     :ext_management_system => @ems,
+                                     :subscription          => subscription2,
+                                     :source_region         => region1,
+                                   )
+          )
+          vm5 = FactoryGirl.create(:vm_cloud,
+                                   vm_data(5).merge(
+                                     :ext_management_system => @ems,
+                                     :subscription          => subscription1,
+                                     :source_region         => region2,
+                                   )
+          )
+          vm6 = FactoryGirl.create(:vm_cloud,
+                                   vm_data(6).merge(
+                                     :ext_management_system => @ems,
+                                     :subscription          => subscription1,
+                                     :source_region         => region1,
+                                   )
+          )
+
+
+          expect(Vm.active.pluck(:ems_ref)).to(
+            match_array([vm_data(1)[:ems_ref], vm_data(2)[:ems_ref], vm_data(3)[:ems_ref], vm_data(4)[:ems_ref],
+                         vm_data(5)[:ems_ref], vm_data(6)[:ems_ref]])
+          )
+          expect(Vm.archived.pluck(:ems_ref)).to(
+            match_array([])
+          )
+
+          persister.vms.build(vm_data(3))
+
+          persister.vms.all_manager_uuids       = [{'ems_ref' => vm1.ems_ref}]
+          persister.vms.all_manager_uuids_scope = [
+            {:source_region => persister.source_regions.lazy_find("region1"), :subscription => persister.subscriptions.lazy_find("subscription1")},
+            {:source_region => persister.source_regions.lazy_find("region2"), :subscription => persister.subscriptions.lazy_find("subscription1")}
+          ]
+
+          persister.persist!
+
+          expect(Vm.active.pluck(:ems_ref)).to(
+            match_array([vm_data(1)[:ems_ref], vm_data(2)[:ems_ref], vm_data(3)[:ems_ref], vm_data(4)[:ems_ref]])
+          )
+          expect(Vm.archived.pluck(:ems_ref)).to(
+            match_array([vm_data(5)[:ems_ref], vm_data(6)[:ems_ref]])
+          )
+        end
+
+        it "fails if all_manager_uuids_scope is using wrong relation" do
+          persister = create_persister(extra_options.merge(:retention_strategy => "archive"))
+
+          persister.vms.all_manager_uuids = []
+          persister.vms.all_manager_uuids_scope = [
+            {:non_existent_relation => persister.source_regions.lazy_find("region1"), :subscription => persister.subscriptions.lazy_find("subscription1")},
+            {:non_existent_relation => persister.source_regions.lazy_find("region2"), :subscription => persister.subscriptions.lazy_find("subscription1")}
+          ]
+
+          expect { persister.persist! }.to(
+            raise_error("'InventoryCollection:<Vm>, blacklist: [genealogy_parent], strategy: local_db_find_missing_references' doesn't have relation :non_existent_relation provided in :all_manager_uuids_scope.")
+          )
+        end
+
+        it "fails if all_manager_uuids_scope is pointing to the wrong value" do
+          persister = create_persister(extra_options.merge(:retention_strategy => "archive"))
+
+          persister.vms.all_manager_uuids = []
+          persister.vms.all_manager_uuids_scope = [
+            {:source_region => persister.source_regions.lazy_find("region1_fake", :key => :name), :subscription => persister.subscriptions.lazy_find("subscription1")},
+            {:source_region => persister.source_regions.lazy_find("region2"), :subscription => persister.subscriptions.lazy_find("subscription1")}
+          ]
+
+          expect { persister.persist! }.to(
+            raise_error("'InventoryCollection:<Vm>, blacklist: [genealogy_parent], strategy: local_db_find_missing_references'"\
+                        " couldn't load scope value :source_region => InventoryObjectLazy:('region1_fake',"\
+                        " InventoryCollection:<SourceRegion>, strategy: local_db_find_missing_references,"\
+                        " ref: manager_ref, key: name) provided in :all_manager_uuids_scope")
+          )
+        end
+
+        it "fails if all_manager_uuids_scope have inconsistent keys" do
+          region1 = FactoryGirl.create(:source_region, :ems_ref => "region1", :ext_management_system => @ems)
+
+          persister = create_persister(extra_options.merge(:retention_strategy => "archive"))
+
+          persister.vms.all_manager_uuids = []
+          persister.vms.all_manager_uuids_scope = [
+            {:source_region => persister.source_regions.lazy_find("region1")},
+            {:source_region => persister.source_regions.lazy_find("region2"), :subscription => persister.subscriptions.lazy_find("subscription1")}
+          ]
+
+          expect { persister.persist! }.to(
+            raise_error("'InventoryCollection:<Vm>, blacklist: [genealogy_parent], strategy: local_db_find_missing_references'"\
+                        " expected keys for :all_manager_uuids_scope are [:source_region], got [:source_region, :subscription]."\
+                        " Keys must be the same for all scopes provided.")
+          )
+        end
+      end
+
       context "not providing nested hardware, disks and networks" do
         it "archives the data with :retention_strategy => 'archive' and with #{extra_options}" do
           persister = create_persister(extra_options.merge(:retention_strategy => "archive"))

--- a/spec/persister/retention_strategies_spec.rb
+++ b/spec/persister/retention_strategies_spec.rb
@@ -67,49 +67,42 @@ describe InventoryRefresh::Persister do
           region2 = FactoryGirl.create(:source_region, :ems_ref => "region2", :ext_management_system => @ems)
           region3 = FactoryGirl.create(:source_region, :ems_ref => "region3", :ext_management_system => @ems)
 
-          vm1  = FactoryGirl.create(:vm_cloud,
-                                    vm_data(1).merge(
-                                      :ext_management_system => @ems,
-                                      :subscription          => subscription1,
-                                      :source_region         => region1,
-                                    )
-          )
+          vm1 = FactoryGirl.create(:vm_cloud,
+                                   vm_data(1).merge(
+                                     :ext_management_system => @ems,
+                                     :subscription          => subscription1,
+                                     :source_region         => region1,
+                                   ))
           _vm2 = FactoryGirl.create(:vm_cloud,
                                     vm_data(2).merge(
                                       :ext_management_system => @ems,
                                       :subscription          => subscription2,
                                       :source_region         => region2,
-                                    )
-          )
+                                    ))
           _vm3 = FactoryGirl.create(:vm_cloud,
                                     vm_data(3).merge(
                                       :ext_management_system => @ems,
                                       :subscription          => subscription2,
                                       :source_region         => region3,
-                                    )
-          )
+                                    ))
           _vm4 = FactoryGirl.create(:vm_cloud,
                                     vm_data(4).merge(
                                       :ext_management_system => @ems,
                                       :subscription          => subscription2,
                                       :source_region         => region1,
-                                    )
-          )
+                                    ))
           _vm5 = FactoryGirl.create(:vm_cloud,
                                     vm_data(5).merge(
                                       :ext_management_system => @ems,
                                       :subscription          => subscription1,
                                       :source_region         => region2,
-                                    )
-          )
+                                    ))
           _vm6 = FactoryGirl.create(:vm_cloud,
                                     vm_data(6).merge(
                                       :ext_management_system => @ems,
                                       :subscription          => subscription1,
                                       :source_region         => region1,
-                                    )
-          )
-
+                                    ))
 
           expect(Vm.active.pluck(:ems_ref)).to(
             match_array([vm_data(1)[:ems_ref], vm_data(2)[:ems_ref], vm_data(3)[:ems_ref], vm_data(4)[:ems_ref],
@@ -393,9 +386,9 @@ describe InventoryRefresh::Persister do
   end
 
   it "checks valid retentions strategies" do
-    expect {
+    expect do
       create_persister(:retention_strategy => "made_up_name", :saver_strategy => 'batch')
-    }.to(
+    end.to(
       raise_error("Unknown InventoryCollection retention strategy: :made_up_name, allowed strategies are :destroy and :archive")
     )
   end
@@ -415,7 +408,7 @@ describe InventoryRefresh::Persister do
       :active_disks           => Disk.active.count,
       :archived_disks         => Disk.archived.count,
       :active_networks        => Network.active.count,
-      :archived_networks      => Network.archived.count,
+      :archived_networks      => Network.archived.count
     }
   end
 

--- a/spec/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/save_inventory/single_inventory_collection_spec.rb
@@ -315,6 +315,7 @@ describe InventoryRefresh::SaveInventory do
 
         expect(@persister.vms.attributes_whitelist).to match_array(%i(__feedback_edge_set_parent
                                                                       __parent_inventory_collections
+                                                                      __all_manager_uuids_scope
                                                                       ems_ref
                                                                       name
                                                                       location
@@ -344,6 +345,7 @@ describe InventoryRefresh::SaveInventory do
         end
         expect(@persister.vms.attributes_whitelist).to match_array(%i(__feedback_edge_set_parent
                                                                       __parent_inventory_collections
+                                                                      __all_manager_uuids_scope
                                                                       uid_ems
                                                                       name
                                                                       location

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -155,6 +155,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.integer  "memory_hot_add_limit"
     t.integer  "memory_hot_add_increment"
     t.string   "hostname"
+    t.bigint   "source_region_id"
+    t.bigint   "subscription_id"
     t.datetime "archived_on"
     t.index ["availability_zone_id"], name: "index_vms_on_availability_zone_id", using: :btree
     t.index ["evm_owner_id"], name: "index_vms_on_evm_owner_id", using: :btree
@@ -167,6 +169,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.index ["storage_id"], name: "index_vms_on_storage_id", using: :btree
     t.index ["type"], name: "index_vms_on_type", using: :btree
     t.index ["uid_ems"], name: "index_vms_on_vmm_uuid", using: :btree
+    t.index ["source_region_id"], name: "index_vms_on_source_region_id", using: :btree
+    t.index ["subscription_id"], name: "index_vms_on_subscription_id", using: :btree
     t.index ["archived_on"], name: "index_vms_on_archived_on", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_vms_on_ems_id_and_ems_ref", unique: true, using: :btree
   end
@@ -577,7 +581,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "resource_version_string"
     t.string   "restart_policy"
     t.string   "dns_policy"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.bigint   "container_node_id"
     t.datetime "last_perf_capture_on"
     t.bigint   "container_replicator_id"
@@ -629,7 +633,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.integer  "last_signal"
     t.string   "last_message"
     t.datetime "archived_on"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.bigint   "old_ems_id"
     t.float    "request_cpu_cores"
     t.bigint   "request_memory_bytes"
@@ -664,7 +668,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "name"
     t.string   "image_ref"
     t.bigint   "container_image_registry_id"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.datetime "last_sync_on"
     t.datetime "last_scan_attempt_on"
     t.string   "digest"
@@ -759,5 +763,30 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.datetime "created_on"
     t.index ["ems_id", "ems_ref"], name: "index_container_build_pods_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["ems_id"], name: "index_container_build_pods_on_ems_id", using: :btree
+  end
+
+  create_table "source_regions", force: :cascade do |t|
+    t.bigint "ems_id", null: false
+    t.string "ems_ref"
+    t.string "name"
+    t.string "endpoint"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "archived_on"
+    t.index ["archived_on"], name: "index_source_regions_on_archived_on"
+    t.index ["ems_id", "ems_ref"], name: "index_source_regions_on_ems_id_and_ems_ref", unique: true
+    t.index ["ems_id"], name: "index_source_regions_on_ems_id"
+  end
+
+  create_table "subscriptions", force: :cascade do |t|
+    t.bigint "ems_id", null: false
+    t.string "ems_ref"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "archived_on"
+    t.index ["archived_on"], name: "index_subscriptions_on_archived_on"
+    t.index ["ems_id", "ems_ref"], name: "index_subscriptions_on_ems_id_and_ems_ref", unique: true
+    t.index ["ems_id"], name: "index_subscriptions_on_ems_id"
   end
 end


### PR DESCRIPTION
Make it possible to scope all_manager_uuids only to some group. E.g. if we want to send all_manager_uuids but only under 1 or more regions.