### PR TITLE
Use define_singleton_method so we store the methods only on instance

### DIFF
--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -64,7 +64,7 @@ module InventoryRefresh
     # @return [InventoryRefresh::InventoryCollection] returns a defined InventoryCollection or undefined method
     def method_missing(method_name, *arguments, &block)
       if inventory_collections_names.include?(method_name)
-        self.class.define_collections_reader(method_name)
+        self.define_collections_reader(method_name)
         send(method_name)
       else
         super
@@ -77,8 +77,8 @@ module InventoryRefresh
     end
 
     # Defines a new attr reader returning InventoryCollection object
-    def self.define_collections_reader(collection_key)
-      define_method(collection_key) do
+    def define_collections_reader(collection_key)
+      define_singleton_method(collection_key) do
         collections[collection_key]
       end
     end


### PR DESCRIPTION
Storing the method on Persister class is causing a sporadic failure
where we test respond_to be_falsey, but a spec before can set it on
the class. In general, lets not cache dynamic methods on the class.

Sporadic failure was on the line https://github.com/Ladas/inventory_refresh/blob/a316ff691d7d2b7434d6e3ecf3d78458c4214c57/spec/persister/persister_spec.rb#L22