### PR TITLE
Do not store all deleted ids

### DIFF
--- a/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
+++ b/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
@@ -385,9 +385,10 @@ module InventoryRefresh
         end
 
         def init_changed_records_stats
-          @created_records = []
-          @updated_records = []
-          @deleted_records = []
+          @created_records       = []
+          @updated_records       = []
+          @deleted_records       = []
+          @deleted_records_count = 0
         end
 
         # Processes passed saver strategy

--- a/lib/inventory_refresh/save_collection/saver/retention_helper.rb
+++ b/lib/inventory_refresh/save_collection/saver/retention_helper.rb
@@ -22,7 +22,7 @@ module InventoryRefresh::SaveCollection
         end
 
         logger.debug("Processing :delete_complement of #{inventory_collection} of size "\
-                     "#{all_manager_uuids_size}, deleted=#{inventory_collection.deleted_records.size}...Complete")
+                     "#{all_manager_uuids_size}, deleted=#{inventory_collection.deleted_records_count}...Complete")
       end
 
       # Applies strategy based on :retention_strategy parameter, or fallbacks to legacy_destroy_records.


### PR DESCRIPTION
We can have a lot of deleted records, which can cause massive memory
spike. So we will count deleted records, but only store ids of a
subset, with TODO that we should be streaming the ids as they come
to a messaging service, not store them around.