### PR TITLE
Store unconnected edges

### DIFF
--- a/lib/inventory_refresh/inventory_collection.rb
+++ b/lib/inventory_refresh/inventory_collection.rb
@@ -193,7 +193,7 @@ module InventoryRefresh
       (@unconnected_edges ||= []) <<
         InventoryRefresh::InventoryCollection::UnconnectedEdge.new(
           inventory_object, inventory_object_key, inventory_object_lazy
-      )
+        )
     end
 
     # Caches what records were created, for later use, e.g. post provision behavior

--- a/lib/inventory_refresh/inventory_collection.rb
+++ b/lib/inventory_refresh/inventory_collection.rb
@@ -5,6 +5,7 @@ require "inventory_refresh/inventory_collection/reference"
 require "inventory_refresh/inventory_collection/references_storage"
 require "inventory_refresh/inventory_collection/scanner"
 require "inventory_refresh/inventory_collection/serialization"
+require "inventory_refresh/inventory_collection/unconnected_edge"
 require "inventory_refresh/inventory_collection/helpers/initialize_helper"
 require "inventory_refresh/inventory_collection/helpers/associations_helper"
 require "inventory_refresh/inventory_collection/helpers/questions_helper"
@@ -97,7 +98,7 @@ module InventoryRefresh
                 :inventory_object_attributes, :name, :saver_strategy, :targeted_scope, :default_values,
                 :targeted_arel, :targeted, :manager_ref_allowed_nil, :use_ar_object,
                 :created_records, :updated_records, :deleted_records, :retention_strategy,
-                :custom_reconnect_block, :batch_extra_attributes, :references_storage
+                :custom_reconnect_block, :batch_extra_attributes, :references_storage, :unconnected_edges
 
     delegate :<<,
              :build,
@@ -186,6 +187,13 @@ module InventoryRefresh
       init_storages
 
       init_changed_records_stats
+    end
+
+    def store_unconnected_edges(inventory_object, inventory_object_key, inventory_object_lazy)
+      (@unconnected_edges ||= []) <<
+        InventoryRefresh::InventoryCollection::UnconnectedEdge.new(
+          inventory_object, inventory_object_key, inventory_object_lazy
+      )
     end
 
     # Caches what records were created, for later use, e.g. post provision behavior

--- a/lib/inventory_refresh/inventory_collection/reference.rb
+++ b/lib/inventory_refresh/inventory_collection/reference.rb
@@ -35,6 +35,10 @@ module InventoryRefresh
         nested_secondary_index
       end
 
+      def loadable?
+        keys.any? { |attribute| full_reference[attribute].present? }
+      end
+
       class << self
         # Builds string uuid from passed Hash and keys
         #

--- a/lib/inventory_refresh/inventory_collection/scanner.rb
+++ b/lib/inventory_refresh/inventory_collection/scanner.rb
@@ -85,6 +85,11 @@ module InventoryRefresh
           end
         end
 
+        # Scan InventoryCollection skeletal data
+        inventory_collection.skeletal_primary_index.each_value do |inventory_object|
+          scan_inventory_object!(inventory_object)
+        end
+
         build_parent_inventory_collections!
         scan_all_manager_uuids_scope!
 

--- a/lib/inventory_refresh/inventory_collection/unconnected_edge.rb
+++ b/lib/inventory_refresh/inventory_collection/unconnected_edge.rb
@@ -1,0 +1,19 @@
+require "active_support/core_ext/module/delegation"
+
+module InventoryRefresh
+  class InventoryCollection
+    class UnconnectedEdge
+      attr_reader :inventory_object, :inventory_object_key, :inventory_object_lazy
+
+      # @param inventory_object [InventoryRefresh::InventoryObject] InventoryObject that couldn't connect the relation
+      # @param inventory_object_key [String] Relation name that couldn't be connected
+      # @param inventory_object_lazy [InventoryRefresh::InventoryObjectLazy] The lazy relation that failed to load
+      #                              this can happen only for relations with key, or pointing to DB only relations
+      def initialize(inventory_object, inventory_object_key, inventory_object_lazy)
+        @inventory_object      = inventory_object
+        @inventory_object_key  = inventory_object_key
+        @inventory_object_lazy = inventory_object_lazy
+      end
+    end
+  end
+end

--- a/lib/inventory_refresh/inventory_object.rb
+++ b/lib/inventory_refresh/inventory_object.rb
@@ -31,7 +31,7 @@ module InventoryRefresh
     end
 
     # @return [InventoryRefresh::InventoryObject] returns self
-    def load
+    def load(*args)
       self
     end
 
@@ -98,7 +98,7 @@ module InventoryRefresh
     # @param inventory_collection_scope [InventoryRefresh::InventoryCollection] parent InventoryCollection object
     # @param all_attribute_keys [Array<Symbol>] Attribute keys we will modify based on object's data
     # @return [Hash] Data in DB format
-    def attributes_with_keys(inventory_collection_scope = nil, all_attribute_keys = [])
+    def attributes_with_keys(inventory_collection_scope = nil, all_attribute_keys = [], inventory_object = nil)
       # We should explicitly pass a scope, since the inventory_object can be mapped to more InventoryCollections with
       # different blacklist and whitelist. The generic code always passes a scope.
       inventory_collection_scope ||= inventory_collection
@@ -111,7 +111,7 @@ module InventoryRefresh
         elsif loadable?(value) || inventory_collection_scope.association_to_foreign_key_mapping[key]
           # Lets fill also the original data, so other InventoryObject referring to this attribute gets the right
           # result
-          data[key] = value.load if value.respond_to?(:load)
+          data[key] = value.load(inventory_object, key) if value.respond_to?(:load)
           if (foreign_key = inventory_collection_scope.association_to_foreign_key_mapping[key])
             # We have an association to fill, lets fill also the :key, cause some other InventoryObject can refer to it
             record_id = data[key].try(:id)

--- a/lib/inventory_refresh/inventory_object.rb
+++ b/lib/inventory_refresh/inventory_object.rb
@@ -97,6 +97,7 @@ module InventoryRefresh
     #
     # @param inventory_collection_scope [InventoryRefresh::InventoryCollection] parent InventoryCollection object
     # @param all_attribute_keys [Array<Symbol>] Attribute keys we will modify based on object's data
+    # @param inventory_object [InventoryRefresh::InventoryObject] InventoryObject object owning these attributes
     # @return [Hash] Data in DB format
     def attributes_with_keys(inventory_collection_scope = nil, all_attribute_keys = [], inventory_object = nil)
       # We should explicitly pass a scope, since the inventory_object can be mapped to more InventoryCollections with

--- a/lib/inventory_refresh/inventory_object.rb
+++ b/lib/inventory_refresh/inventory_object.rb
@@ -31,7 +31,7 @@ module InventoryRefresh
     end
 
     # @return [InventoryRefresh::InventoryObject] returns self
-    def load(*args)
+    def load(*_args)
       self
     end
 

--- a/lib/inventory_refresh/inventory_object_lazy.rb
+++ b/lib/inventory_refresh/inventory_object_lazy.rb
@@ -44,10 +44,16 @@ module InventoryRefresh
 
     # @return [InventoryRefresh::InventoryObject, Object] InventoryRefresh::InventoryObject instance or an attribute
     #         on key
-    def load
+    def load(inventory_object = nil, inventory_object_key = nil)
       transform_nested_secondary_indexes! if transform_nested_lazy_finds && nested_secondary_index?
 
-      key ? load_object_with_key : load_object
+      loaded_object = key ? load_object_with_key : load_object
+      if inventory_object && inventory_object_key && !loaded_object && reference.loadable?
+        # Object was not loaded, but the reference is pointing to something, lets return it as edge that should've
+        # been loaded.
+        inventory_object.inventory_collection.store_unconnected_edges(inventory_object, inventory_object_key, self)
+      end
+      loaded_object
     end
 
     # return [Boolean] true if the Lazy object is causing a dependency, Lazy link is always a dependency if no :key

--- a/lib/inventory_refresh/inventory_object_lazy.rb
+++ b/lib/inventory_refresh/inventory_object_lazy.rb
@@ -42,18 +42,14 @@ module InventoryRefresh
       "InventoryObjectLazy:('#{self}', #{inventory_collection}#{suffix})"
     end
 
+    # @param inventory_object [InventoryRefresh::InventoryObject] InventoryObject object owning this relation
+    # @param inventory_object_key [Symbol] InventoryObject object's attribute pointing to this relation
     # @return [InventoryRefresh::InventoryObject, Object] InventoryRefresh::InventoryObject instance or an attribute
     #         on key
     def load(inventory_object = nil, inventory_object_key = nil)
       transform_nested_secondary_indexes! if transform_nested_lazy_finds && nested_secondary_index?
 
-      loaded_object = key ? load_object_with_key : load_object
-      if inventory_object && inventory_object_key && !loaded_object && reference.loadable?
-        # Object was not loaded, but the reference is pointing to something, lets return it as edge that should've
-        # been loaded.
-        inventory_object.inventory_collection.store_unconnected_edges(inventory_object, inventory_object_key, self)
-      end
-      loaded_object
+      load_object(inventory_object, inventory_object_key)
     end
 
     # return [Boolean] true if the Lazy object is causing a dependency, Lazy link is always a dependency if no :key
@@ -134,15 +130,15 @@ module InventoryRefresh
       skeletal_primary_index.build(full_reference)
     end
 
+    # @param loaded_object [InventoryRefresh::InventoryObject, NilClass] Loaded object or nil if object wasn't found
     # @return [Object] value found or :key or default value if the value is nil
-    def load_object_with_key
+    def load_object_with_key(loaded_object)
       # TODO(lsmola) Log error if we are accessing path that is present in blacklist or not present in whitelist
-      found = inventory_collection.find(reference)
-      if found.present?
-        if found.try(:data).present?
-          found.data[key] || default
+      if loaded_object.present?
+        if loaded_object.try(:data).present?
+          loaded_object.data[key] || default
         else
-          found.public_send(key) || default
+          loaded_object.public_send(key) || default
         end
       else
         default
@@ -150,8 +146,16 @@ module InventoryRefresh
     end
 
     # @return [InventoryRefresh::InventoryObject, NilClass] InventoryRefresh::InventoryObject instance or nil if not found
-    def load_object
-      inventory_collection.find(reference)
+    def load_object(inventory_object = nil, inventory_object_key = nil)
+      loaded_object = inventory_collection.find(reference)
+
+      if inventory_object && inventory_object_key && !loaded_object && reference.loadable?
+        # Object was not loaded, but the reference is pointing to something, lets return it as edge that should've
+        # been loaded.
+        inventory_object.inventory_collection.store_unconnected_edges(inventory_object, inventory_object_key, self)
+      end
+
+      key ? load_object_with_key(loaded_object) : loaded_object
     end
   end
 end

--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -112,7 +112,11 @@ module InventoryRefresh
       end.compact
 
       {
-        :collections => collections_data
+        :refresh_state_uuid      => refresh_state_uuid,
+        :refresh_state_part_uuid => refresh_state_part_uuid,
+        :total_parts             => total_parts,
+        :sweep_scope             => sweep_scope,
+        :collections             => collections_data,
       }
     end
 

--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -5,7 +5,7 @@ module InventoryRefresh
 
     attr_reader :manager, :target, :collections
 
-    attr_accessor :refresh_state_uuid, :refresh_state_part_uuid, :total_parts, :sweep_scope
+    attr_accessor :refresh_state_uuid, :refresh_state_part_uuid, :total_parts, :sweep_scope, :retry_count, :retry_max
 
     # @param manager [ManageIQ::Providers::BaseManager] A manager object
     # @param target [Object] A refresh Target object
@@ -114,6 +114,8 @@ module InventoryRefresh
       {
         :refresh_state_uuid      => refresh_state_uuid,
         :refresh_state_part_uuid => refresh_state_part_uuid,
+        :retry_count             => retry_count,
+        :retry_max               => retry_max,
         :total_parts             => total_parts,
         :sweep_scope             => sweep_scope,
         :collections             => collections_data,
@@ -147,6 +149,8 @@ module InventoryRefresh
 
           persister.refresh_state_uuid      = persister_data['refresh_state_uuid']
           persister.refresh_state_part_uuid = persister_data['refresh_state_part_uuid']
+          persister.retry_count             = persister_data['retry_count']
+          persister.retry_max               = persister_data['retry_max']
           persister.total_parts             = persister_data['total_parts']
           persister.sweep_scope             = persister_data['sweep_scope']
         end

--- a/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -364,7 +364,7 @@ module InventoryRefresh::SaveCollection
         skeletal_inventory_objects_index = {}
 
         inventory_collection.skeletal_primary_index.each_value do |inventory_object|
-          attributes = inventory_object.attributes_with_keys(inventory_collection, all_attribute_keys)
+          attributes = inventory_object.attributes_with_keys(inventory_collection, all_attribute_keys, inventory_object)
           index      = build_stringified_reference(attributes, unique_index_keys)
 
           skeletal_attributes_index[index]        = attributes

--- a/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -87,7 +87,7 @@ module InventoryRefresh::SaveCollection
         all_attribute_keys      = Set.new + inventory_collection.batch_extra_attributes
 
         inventory_collection.each do |inventory_object|
-          attributes = inventory_object.attributes_with_keys(inventory_collection, all_attribute_keys)
+          attributes = inventory_object.attributes_with_keys(inventory_collection, all_attribute_keys, inventory_object)
           index      = build_stringified_reference(attributes, unique_index_keys)
 
           # Interesting fact: not building attributes_index and using only inventory_objects_index doesn't do much
@@ -347,6 +347,9 @@ module InventoryRefresh::SaveCollection
         # saved are not being sent here. We have only rows that are new, but become old as we send the query (so other
         # parallel process saved the data in the meantime). Or if some attributes are newer than the whole row
         # being sent.
+        #
+        # TODO(lsmola) we should have a timestamp check here, so we don't create skeletal objects from old rows, right
+        # now, we create skeletal objects if the timestamps are equal?
         hash.each_key do |db_index|
           inventory_collection.skeletal_primary_index.skeletonize_primary_index(hash[db_index].manager_uuid)
         end

--- a/spec/helpers/spec_parsed_data.rb
+++ b/spec/helpers/spec_parsed_data.rb
@@ -197,6 +197,7 @@ module SpecParsedData
       :ems_ref                 => "container_project_ems_ref_#{i}",
       :name                    => "container_project_name_#{i}",
       :ems_created_on          => "2015-07-29T12:50:33Z",
+      :display_name            => "container_project_display_name_#{i}",
       :resource_version_string => 6
     }.merge(data)
   end

--- a/spec/persister/unconnected_edges_spec.rb
+++ b/spec/persister/unconnected_edges_spec.rb
@@ -69,6 +69,55 @@ describe InventoryRefresh::Persister do
         expect(unconnected_edge.inventory_object_lazy.to_s).to eq(container_project_data(3)[:name])
         expect(unconnected_edge.inventory_object_lazy).to be_a(InventoryRefresh::InventoryObjectLazy)
       end
+
+      it "tests unconnected edges are found for lazy_find with key acessor" do
+        FactoryGirl.create(:container_project, container_project_data(1).merge(:ems_id => @ems.id))
+        FactoryGirl.create(:container_project, container_project_data(2).merge(:ems_id => @ems.id))
+
+        persister.container_groups.build(
+          container_group_data(
+            1,
+            :dns_policy => persister.container_projects.lazy_find(
+              {:name => container_project_data(1)[:name]}, {:ref => :by_name, :key => :display_name}
+            ),
+          )
+        )
+        persister.container_groups.build(
+          container_group_data(
+            2,
+            :dns_policy => persister.container_projects.lazy_find(
+              {:name => container_project_data(2)[:name]}, {:ref => :by_name, :key => :display_name}
+            ),
+          )
+        )
+        persister.container_groups.build(
+          container_group_data(
+            3,
+            :dns_policy => persister.container_projects.lazy_find(
+              {:name => container_project_data(3)[:name]}, {:ref => :by_name, :key => :display_name}
+            ),
+          )
+        )
+
+        persister.container_projects.build(container_project_data(2))
+
+        persister.persist!
+
+        # Assert container_group and container_image are pre-created using the lazy_find data
+        assert_containers_counts(
+          :container_group   => 3,
+          :container_project => 2,
+        )
+
+        expect(persister.container_groups.unconnected_edges.size).to eq(1)
+        unconnected_edge = persister.container_groups.unconnected_edges.first
+        expect(unconnected_edge).to be_a(InventoryRefresh::InventoryCollection::UnconnectedEdge)
+        expect(unconnected_edge.inventory_object.ems_ref).to eq(container_group_data(3)[:ems_ref])
+        expect(unconnected_edge.inventory_object).to be_a(InventoryRefresh::InventoryObject)
+        expect(unconnected_edge.inventory_object_key).to eq(:dns_policy)
+        expect(unconnected_edge.inventory_object_lazy.to_s).to eq(container_project_data(3)[:name])
+        expect(unconnected_edge.inventory_object_lazy).to be_a(InventoryRefresh::InventoryObjectLazy)
+      end
     end
   end
 end

--- a/spec/persister/unconnected_edges_spec.rb
+++ b/spec/persister/unconnected_edges_spec.rb
@@ -1,0 +1,74 @@
+require_relative '../helpers/spec_mocked_data'
+require_relative '../helpers/spec_parsed_data'
+require_relative 'targeted_refresh_spec_helper'
+
+describe InventoryRefresh::Persister do
+  include SpecMockedData
+  include SpecParsedData
+  include TargetedRefreshSpecHelper
+
+  ######################################################################################################################
+  # Spec scenarios for making sure the skeletal pre-create passes
+  ######################################################################################################################
+
+  [
+    {}
+  ].each do |settings|
+    context "with settings #{settings}" do
+      before :each do
+        @ems = FactoryGirl.create(:ems_container)
+      end
+
+      let(:persister) { create_containers_persister }
+
+      it "tests unconnected edges are found" do
+        FactoryGirl.create(:container_project, container_project_data(1).merge(:ems_id => @ems.id))
+        FactoryGirl.create(:container_project, container_project_data(2).merge(:ems_id => @ems.id))
+
+        persister.container_groups.build(
+          container_group_data(
+            1,
+            :container_project => persister.container_projects.lazy_find(
+              {:name => container_project_data(1)[:name]}, {:ref => :by_name}
+            ),
+          )
+        )
+        persister.container_groups.build(
+          container_group_data(
+            2,
+            :container_project => persister.container_projects.lazy_find(
+              {:name => container_project_data(2)[:name]}, {:ref => :by_name}
+            ),
+          )
+        )
+        persister.container_groups.build(
+          container_group_data(
+            3,
+            :container_project => persister.container_projects.lazy_find(
+              {:name => container_project_data(3)[:name]}, {:ref => :by_name}
+            ),
+          )
+        )
+
+        persister.container_projects.build(container_project_data(2))
+
+        persister.persist!
+
+        # Assert container_group and container_image are pre-created using the lazy_find data
+        assert_containers_counts(
+          :container_group   => 3,
+          :container_project => 2,
+        )
+
+        expect(persister.container_groups.unconnected_edges.size).to eq(1)
+        unconnected_edge = persister.container_groups.unconnected_edges.first
+        expect(unconnected_edge).to be_a(InventoryRefresh::InventoryCollection::UnconnectedEdge)
+        expect(unconnected_edge.inventory_object.ems_ref).to eq(container_group_data(3)[:ems_ref])
+        expect(unconnected_edge.inventory_object).to be_a(InventoryRefresh::InventoryObject)
+        expect(unconnected_edge.inventory_object_key).to eq(:container_project)
+        expect(unconnected_edge.inventory_object_lazy.to_s).to eq(container_project_data(3)[:name])
+        expect(unconnected_edge.inventory_object_lazy).to be_a(InventoryRefresh::InventoryObjectLazy)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Store unconnected edges

We want to keep track of what edges weren't created, while they
should have been. Meaning the reference exists, but we weren't
able to find the node to connect to. This can happen when we
use DB only strategy, or lazy_find with secondary indexes.

Depends on:
- [x] https://github.com/ManageIQ/inventory_refresh/pull/45