### PR TITLE
Allow to partial update with the same timestamp

### DIFF
--- a/lib/inventory_refresh/save_collection/saver/sql_helper_upsert.rb
+++ b/lib/inventory_refresh/save_collection/saver/sql_helper_upsert.rb
@@ -128,7 +128,7 @@ module InventoryRefresh::SaveCollection
           , #{attr_partial} = '{}', #{attr_partial_max} = NULL
 
           WHERE EXCLUDED.#{attr_full} IS NULL OR (
-            (#{q_table_name}.#{attr_full} IS NULL OR EXCLUDED.#{attr_full} > #{q_table_name}.#{attr_full}) AND
+            (#{q_table_name}.#{attr_full} IS NULL OR EXCLUDED.#{attr_full} >= #{q_table_name}.#{attr_full}) AND
             (#{q_table_name}.#{attr_partial_max} IS NULL OR EXCLUDED.#{attr_full} >= #{q_table_name}.#{attr_partial_max})
           )
         SQL
@@ -154,9 +154,9 @@ module InventoryRefresh::SaveCollection
           #{insert_query_set_jsonb_version(cast, attr_partial, attr_partial_max, column_name)}
           , #{attr_partial_max} = greatest(#{q_table_name}.#{attr_partial_max}::#{cast}, EXCLUDED.#{attr_partial_max}::#{cast})
           WHERE EXCLUDED.#{attr_partial_max} IS NULL OR (
-            (#{q_table_name}.#{attr_full} IS NULL OR EXCLUDED.#{attr_partial_max} > #{q_table_name}.#{attr_full}) AND (
+            (#{q_table_name}.#{attr_full} IS NULL OR EXCLUDED.#{attr_partial_max} >= #{q_table_name}.#{attr_full}) AND (
               (#{q_table_name}.#{attr_partial}->>'#{column_name}')::#{cast} IS NULL OR
-              EXCLUDED.#{attr_partial_max}::#{cast} > (#{q_table_name}.#{attr_partial}->>'#{column_name}')::#{cast}
+              EXCLUDED.#{attr_partial_max}::#{cast} >= (#{q_table_name}.#{attr_partial}->>'#{column_name}')::#{cast}
             )
           )
         SQL

--- a/spec/persister/parallel_saving_spec.rb
+++ b/spec/persister/parallel_saving_spec.rb
@@ -196,9 +196,12 @@ describe InventoryRefresh::Persister do
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
           else
-            match_created(persister)
+            if settings[:upsert_only]
+              match_updated(persister, :container_groups => ContainerGroup.all)
+            else
+              match_updated(persister)
+            end
           end
-          match_updated(persister)
           match_deleted(persister)
         end
 
@@ -394,10 +397,11 @@ describe InventoryRefresh::Persister do
 
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
+            match_updated(persister)
           else
             match_created(persister)
+            match_updated(persister, :container_groups => ContainerGroup.all)
           end
-          match_updated(persister)
           match_deleted(persister)
         end
       end
@@ -420,10 +424,16 @@ describe InventoryRefresh::Persister do
 
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
+            match_updated(persister)
           else
             match_created(persister)
+            if settings[:upsert_only]
+              match_updated(persister, :container_groups => ContainerGroup.all)
+            else
+              match_updated(persister)
+            end
           end
-          match_updated(persister)
+
           match_deleted(persister)
         end
 
@@ -443,11 +453,18 @@ describe InventoryRefresh::Persister do
               have_attributes(
                 :name                      => "container_group_#{expected_version}",
                 version_col(settings)      => expected_version,
-                versions_max_col(settings) => nil,
-                versions_col(settings)     => {},
+                versions_max_col(settings) => expected_version,
                 :reason                    => expected_version.to_s,
                 :phase                     => "#{expected_version} status",
               )
+            )
+
+            expect(container_group.send(versions_col(settings))).to(
+              match(
+                "phase"      => expected_version,
+                "dns_policy" => expected_version,
+                "reason"     => expected_version,
+                )
             )
           end
 
@@ -457,7 +474,7 @@ describe InventoryRefresh::Persister do
           expect(container_group_created_on).to eq(container_group_current_created_on)
 
           match_created(persister)
-          match_updated(persister)
+          match_updated(persister, :container_groups => ContainerGroup.all)
           match_deleted(persister)
         end
       end
@@ -496,10 +513,11 @@ describe InventoryRefresh::Persister do
 
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
+            match_updated(persister)
           else
             match_created(persister)
+            match_updated(persister, :container_groups => ContainerGroup.all)
           end
-          match_updated(persister)
           match_deleted(persister)
         end
 
@@ -530,7 +548,11 @@ describe InventoryRefresh::Persister do
           if i == 0
             match_updated(persister, :container_groups => ContainerGroup.all)
           else
-            match_updated(persister)
+            if settings[:upsert_only]
+              match_updated(persister, :container_groups => ContainerGroup.all)
+            else
+              match_updated(persister)
+            end
           end
           match_created(persister)
           match_deleted(persister)
@@ -573,10 +595,11 @@ describe InventoryRefresh::Persister do
 
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
+            match_updated(persister)
           else
             match_created(persister)
+            match_updated(persister, :container_groups => ContainerGroup.all)
           end
-          match_updated(persister)
           match_deleted(persister)
         end
 
@@ -609,7 +632,11 @@ describe InventoryRefresh::Persister do
           if i == 0
             match_updated(persister, :container_groups => ContainerGroup.all)
           else
-            match_updated(persister)
+            if settings[:upsert_only]
+              match_updated(persister, :container_groups => ContainerGroup.all)
+            else
+              match_updated(persister)
+            end
           end
           match_created(persister)
           match_deleted(persister)
@@ -636,10 +663,16 @@ describe InventoryRefresh::Persister do
 
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
+            match_updated(persister)
           else
             match_created(persister)
+            if settings[:upsert_only]
+              match_updated(persister, :container_groups => ContainerGroup.all)
+            else
+              match_updated(persister)
+            end
           end
-          match_updated(persister)
+
           match_deleted(persister)
         end
 
@@ -679,11 +712,7 @@ describe InventoryRefresh::Persister do
           container_group_current_created_on = ContainerGroup.where(:dns_policy => "1").first.created_on
           expect(container_group_created_on).to eq(container_group_current_created_on)
 
-          if i == 0
-            match_updated(persister, :container_groups => ContainerGroup.all)
-          else
-            match_updated(persister)
-          end
+          match_updated(persister, :container_groups => ContainerGroup.all)
           match_created(persister)
           match_deleted(persister)
         end
@@ -701,12 +730,34 @@ describe InventoryRefresh::Persister do
             )
           )
 
+          ContainerGroup.find_each do |container_group|
+            expected_bigger_version = expected_version(settings, container_group, newest_version(settings))
+
+            expect(container_group).to(
+              have_attributes(
+                :name                 => nil,
+                version_col(settings) => nil,
+                :reason               => expected_bigger_version.to_s,
+                :phase                => "#{expected_bigger_version} status",
+              )
+            )
+
+            expect(container_group.send(versions_col(settings))).to(
+              match(
+                "dns_policy" => expected_bigger_version,
+                "phase"      => expected_bigger_version,
+                "reason"     => expected_bigger_version,
+              )
+            )
+          end
+
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
+            match_updated(persister)
           else
             match_created(persister)
+            match_updated(persister, :container_groups => ContainerGroup.all)
           end
-          match_updated(persister)
           match_deleted(persister)
         end
 
@@ -737,7 +788,11 @@ describe InventoryRefresh::Persister do
           if i == 0
             match_updated(persister, :container_groups => ContainerGroup.all)
           else
-            match_updated(persister)
+            if settings[:upsert_only]
+              match_updated(persister, :container_groups => ContainerGroup.all)
+            else
+              match_updated(persister)
+            end
           end
           match_created(persister)
           match_deleted(persister)
@@ -759,10 +814,11 @@ describe InventoryRefresh::Persister do
 
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
+            match_updated(persister)
           else
             match_created(persister)
+            match_updated(persister, :container_groups => ContainerGroup.all)
           end
-          match_updated(persister)
           match_deleted(persister)
         end
 
@@ -832,7 +888,11 @@ describe InventoryRefresh::Persister do
           if i == 0
             match_updated(persister, :container_groups => ContainerGroup.all)
           else
-            match_updated(persister)
+            if settings[:upsert_only]
+              match_updated(persister, :container_groups => ContainerGroup.all)
+            else
+              match_updated(persister, :container_groups => ContainerGroup.where(:dns_policy => %w(0 1)))
+            end
           end
           match_created(persister)
           match_deleted(persister)
@@ -862,10 +922,11 @@ describe InventoryRefresh::Persister do
 
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
+            match_updated(persister)
           else
             match_created(persister)
+            match_updated(persister, :container_groups => ContainerGroup.all)
           end
-          match_updated(persister)
           match_deleted(persister)
 
           persister = TestCollector.refresh(
@@ -902,11 +963,7 @@ describe InventoryRefresh::Persister do
             )
           end
 
-          if i == 0
-            match_updated(persister, :container_groups => ContainerGroup.where(:dns_policy => %w(0 1)))
-          else
-            match_updated(persister)
-          end
+          match_updated(persister, :container_groups => ContainerGroup.where(:dns_policy => %w(0 1)))
           match_created(persister)
           match_deleted(persister)
         end
@@ -1057,10 +1114,15 @@ describe InventoryRefresh::Persister do
 
           if i == 0
             match_created(persister, :container_groups => ContainerGroup.all)
+            match_updated(persister)
           else
             match_created(persister)
+            if settings[:upsert_only]
+              match_updated(persister, :container_groups => ContainerGroup.all)
+            else
+              match_updated(persister)
+            end
           end
-          match_updated(persister)
           match_deleted(persister)
 
           persister = TestCollector.refresh(

--- a/spec/persister/sweep_inactive_records_spec.rb
+++ b/spec/persister/sweep_inactive_records_spec.rb
@@ -18,7 +18,7 @@ describe InventoryRefresh::Persister do
       time_before = Time.now.utc - 20.seconds
       time_after  = Time.now.utc + 20.seconds
 
-      _cg1 = FactoryBot.create(:container_group, container_group_data(1).merge(:ext_management_system => @ems, :resource_timestamp => time_before))
+      cg1 = FactoryBot.create(:container_group, container_group_data(1).merge(:ext_management_system => @ems, :resource_timestamp => time_before))
       _cg2 = FactoryBot.create(:container_group, container_group_data(2).merge(:ext_management_system => @ems, :resource_timestamp => time_after))
       _cg3 = FactoryBot.create(:container_group, container_group_data(3).merge(:ext_management_system => @ems, :resource_timestamp => time_now))
       _cg4 = FactoryBot.create(:container_group, container_group_data(4).merge(:ext_management_system => @ems, :last_seen_at => time_before))
@@ -41,8 +41,8 @@ describe InventoryRefresh::Persister do
       persister.container_groups.build(container_group_data(5).merge(:ext_management_system => @ems, :resource_timestamp => time_before))
       persister.persist!
 
-      # We don't update any records data, but last_seen_at is updated for all records involved
-      expect(persister.container_groups.updated_records).to(match_array([]))
+      # We update just the first record, and last_seen_at is updated for all records involved
+      expect(persister.container_groups.updated_records).to(match_array([{:id => cg1.id}]))
 
       date_field = ContainerGroup.arel_table[:last_seen_at]
       expect(ContainerGroup.where(date_field.gt(time_now)).pluck(:ems_ref)).to(


### PR DESCRIPTION
Allow to partial update with the same timestamp and also allow full upsert with the same timestamp. This will allow us to use the partial update for filling the missing links.

Depends on:
- [x] https://github.com/ManageIQ/inventory_refresh/pull/49