### PR TITLE
Allow more flexibility in the AR version

### DIFF
--- a/inventory_refresh.gemspec
+++ b/inventory_refresh.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 5.0.0.racecar1", "< 5.2"
+  spec.add_dependency "activerecord", "~> 5.0"
   spec.add_dependency "more_core_extensions", "~> 3.5"
   spec.add_dependency "pg", "> 0"
 


### PR DESCRIPTION
Since this gem can be included by multiple apps we should be less picky
about the version of active record that we require.