### PR TITLE
Cleanup shared_options in test_persisters

### DIFF
--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -185,6 +185,10 @@ module InventoryRefresh
       nil
     end
 
+    def saver_strategy
+      :default
+    end
+
     # Persisters for targeted refresh can override to true
     def targeted?
       false
@@ -193,9 +197,10 @@ module InventoryRefresh
     # @return [Hash] kwargs shared for all InventoryCollection objects
     def shared_options
       {
-        :strategy => strategy,
-        :targeted => targeted?,
-        :parent   => manager.presence
+        :saver_strategy => saver_strategy,
+        :strategy       => strategy,
+        :targeted       => targeted?,
+        :parent         => manager.presence
       }
     end
   end

--- a/spec/helpers/test_persister/cloud.rb
+++ b/spec/helpers/test_persister/cloud.rb
@@ -80,11 +80,6 @@ class TestPersister::Cloud < ::TestPersister
   end
 
   def shared_options
-    {
-      :saver_strategy => saver_strategy,
-      :strategy       => strategy,
-      :targeted       => targeted?,
-      :parent         => parent,
-    }.merge(options)
+    super.merge(options)
   end
 end

--- a/spec/helpers/test_persister/containers.rb
+++ b/spec/helpers/test_persister/containers.rb
@@ -31,11 +31,6 @@ class TestPersister::Containers < ::TestPersister
   end
 
   def shared_options
-    {
-      :saver_strategy => saver_strategy,
-      :strategy       => strategy,
-      :targeted       => targeted?,
-      :parent         => manager.presence
-    }.merge(options)
+    super.merge(options)
   end
 end


### PR DESCRIPTION
The TestPersister sub-classes were overriding the shared_options method
from the base