### PR TITLE
Add a flag to check and assert graph integrity

### DIFF
--- a/lib/inventory_refresh/inventory_collection.rb
+++ b/lib/inventory_refresh/inventory_collection.rb
@@ -98,7 +98,8 @@ module InventoryRefresh
                 :inventory_object_attributes, :name, :saver_strategy, :targeted_scope, :default_values,
                 :targeted_arel, :targeted, :manager_ref_allowed_nil, :use_ar_object,
                 :created_records, :updated_records, :deleted_records, :retention_strategy,
-                :custom_reconnect_block, :batch_extra_attributes, :references_storage, :unconnected_edges
+                :custom_reconnect_block, :batch_extra_attributes, :references_storage, :unconnected_edges,
+                :assert_graph_integrity
 
     delegate :<<,
              :build,
@@ -152,7 +153,8 @@ module InventoryRefresh
                  properties[:check_changed],
                  properties[:update_only],
                  properties[:use_ar_object],
-                 properties[:targeted])
+                 properties[:targeted],
+                 properties[:assert_graph_integrity])
 
       init_strategies(properties[:strategy],
                       properties[:saver_strategy],

--- a/lib/inventory_refresh/inventory_collection/builder.rb
+++ b/lib/inventory_refresh/inventory_collection/builder.rb
@@ -13,7 +13,8 @@ module InventoryRefresh
            model_class                  name                    parent
            parent_inventory_collections retention_strategy      strategy
            saver_strategy               secondary_refs          targeted
-           targeted_arel                update_only             use_ar_object).to_set
+           targeted_arel                update_only             use_ar_object
+           assert_graph_integrity).to_set
       end
 
       def allowed_properties

--- a/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
+++ b/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
@@ -178,14 +178,16 @@ module InventoryRefresh
         # @param targeted [Boolean] True if the collection is targeted, in that case it will be leveraging :manager_uuids
         #        :parent_inventory_collections and :targeted_arel to save a subgraph of a data.
         def init_flags(complete, create_only, check_changed,
-                       update_only, use_ar_object, targeted)
-          @complete      = complete.nil? ? true : complete
-          @create_only   = create_only.nil? ? false : create_only
-          @check_changed = check_changed.nil? ? true : check_changed
-          @saved         = false
-          @update_only   = update_only.nil? ? false : update_only
-          @use_ar_object = use_ar_object || false
-          @targeted      = !!targeted
+                       update_only, use_ar_object, targeted,
+                       assert_graph_integrity)
+          @complete               = complete.nil? ? true : complete
+          @create_only            = create_only.nil? ? false : create_only
+          @check_changed          = check_changed.nil? ? true : check_changed
+          @saved                  = false
+          @update_only            = update_only.nil? ? false : update_only
+          @use_ar_object          = use_ar_object || false
+          @targeted               = !!targeted
+          @assert_graph_integrity = assert_graph_integrity.nil? ? true : assert_graph_integrity
         end
 
         # @param attributes_blacklist [Array] Attributes we do not want to include into saving. We cannot blacklist an

--- a/lib/inventory_refresh/inventory_collection/index/proxy.rb
+++ b/lib/inventory_refresh/inventory_collection/index/proxy.rb
@@ -195,7 +195,7 @@ module InventoryRefresh
           # TODO(lsmola) do we need some production logging too? Maybe the refresh log level could drive this
           # Let' do this really slick development and test env, but disable for production, since the checks are pretty
           # slow.
-          # TODO: return if Rails.env.production?
+          return unless inventory_collection.assert_graph_integrity
 
           if manager_uuid.kind_of?(InventoryRefresh::InventoryCollection::Reference)
             # InventoryRefresh::InventoryCollection::Reference has been already asserted, skip

--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -185,6 +185,10 @@ module InventoryRefresh
       nil
     end
 
+    def saver_strategy
+      :default
+    end
+
     # Persisters for targeted refresh can override to true
     def targeted?
       false
@@ -193,9 +197,10 @@ module InventoryRefresh
     # @return [Hash] kwargs shared for all InventoryCollection objects
     def shared_options
       {
-        :strategy => strategy,
-        :targeted => targeted?,
-        :parent   => manager.presence
+        :saver_strategy => saver_strategy,
+        :strategy       => strategy,
+        :targeted       => targeted?,
+        :parent         => manager.presence
       }
     end
   end

--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -194,13 +194,18 @@ module InventoryRefresh
       false
     end
 
+    def assert_graph_integrity?
+      false
+    end
+
     # @return [Hash] kwargs shared for all InventoryCollection objects
     def shared_options
       {
-        :saver_strategy => saver_strategy,
-        :strategy       => strategy,
-        :targeted       => targeted?,
-        :parent         => manager.presence
+        :saver_strategy         => saver_strategy,
+        :strategy               => strategy,
+        :targeted               => targeted?,
+        :parent                 => manager.presence,
+        :assert_graph_integrity => assert_graph_integrity?,
       }
     end
   end

--- a/lib/inventory_refresh/save_collection/saver/base.rb
+++ b/lib/inventory_refresh/save_collection/saver/base.rb
@@ -234,7 +234,7 @@ module InventoryRefresh::SaveCollection
           # Change the InventoryCollection's :association or :arel parameter to return distinct results. The :through
           # relations can return the same record multiple times. We don't want to do SELECT DISTINCT by default, since
           # it can be very slow.
-          if false # TODO: Rails.env.production?
+          unless inventory_collection.assert_graph_integrity
             logger.warn("Please update :association or :arel for #{inventory_collection} to return a DISTINCT result. "\
                         " The duplicate value is being ignored.")
             return false
@@ -260,7 +260,7 @@ module InventoryRefresh::SaveCollection
           subject = "#{hash} of #{inventory_collection} because of missing foreign key #{x} for "\
                     "#{inventory_collection.parent.class.name}:"\
                     "#{inventory_collection.parent.try(:id)}"
-          if false # TODO: Rails.env.production?
+          unless inventory_collection.assert_graph_integrity
             logger.warn("Referential integrity check violated, ignoring #{subject}")
             return false
           else

--- a/spec/helpers/test_persister.rb
+++ b/spec/helpers/test_persister.rb
@@ -20,4 +20,8 @@ class TestPersister < InventoryRefresh::Persister
 
     initialize_inventory_collections
   end
+
+  def assert_graph_integrity?
+    true
+  end
 end

--- a/spec/helpers/test_persister/cloud.rb
+++ b/spec/helpers/test_persister/cloud.rb
@@ -80,11 +80,6 @@ class TestPersister::Cloud < ::TestPersister
   end
 
   def shared_options
-    {
-      :saver_strategy => saver_strategy,
-      :strategy       => strategy,
-      :targeted       => targeted?,
-      :parent         => parent,
-    }.merge(options)
+    super.merge(options)
   end
 end

--- a/spec/helpers/test_persister/containers.rb
+++ b/spec/helpers/test_persister/containers.rb
@@ -31,11 +31,6 @@ class TestPersister::Containers < ::TestPersister
   end
 
   def shared_options
-    {
-      :saver_strategy => saver_strategy,
-      :strategy       => strategy,
-      :targeted       => targeted?,
-      :parent         => manager.presence
-    }.merge(options)
+    super.merge(options)
   end
 end


### PR DESCRIPTION
If this flag is set perform extra checks for graph integrity and raise exceptions if issues are found.
This is helpful in test and development but allows for refresh to complete in production if there are minor issues.

Depends on: https://github.com/ManageIQ/inventory_refresh/pull/59