### PR TITLE
Allow to precreate with empty index value

### DIFF
--- a/lib/inventory_refresh/inventory_object_lazy.rb
+++ b/lib/inventory_refresh/inventory_object_lazy.rb
@@ -123,9 +123,12 @@ module InventoryRefresh
       # Full reference must be present
       return if full_reference.blank?
 
-      # To avoid pre-creating invalid records all fields of a primary key must have value
-      # TODO(lsmola) for composite keys, it's still valid to have one of the keys nil, figure out how to allow this
-      return if keys.any? { |x| full_reference[x].blank? }
+      # To avoid pre-creating invalid records all fields of a primary key must have non null value
+      # TODO(lsmola) for composite keys, it's still valid to have one of the keys nil, figure out how to allow this. We
+      # will need to scan the DB for NOT NULL constraint and allow it based on that. So we would move this check to
+      # saving code, but this will require bigger change, since having the column nil means we will have to batch it
+      # smartly, since having nil means we will need to use different unique index for the upsert/update query.
+      return if keys.any? { |x| full_reference[x].nil? }
 
       skeletal_primary_index.build(full_reference)
     end

--- a/lib/inventory_refresh/inventory_object_lazy.rb
+++ b/lib/inventory_refresh/inventory_object_lazy.rb
@@ -119,9 +119,8 @@ module InventoryRefresh
       # Pre-create only for strategies that will be persisting data, i.e. are not saved already
       return if saved?
       # We can only do skeletal pre-create for primary index reference, since that is needed to create DB unique index
-      return unless primary?
-      # Full reference must be present
-      return if full_reference.blank?
+      # and full reference must be present
+      return if !primary? || full_reference.blank?
 
       # To avoid pre-creating invalid records all fields of a primary key must have non null value
       # TODO(lsmola) for composite keys, it's still valid to have one of the keys nil, figure out how to allow this. We

--- a/spec/helpers/test_builder/container_manager.rb
+++ b/spec/helpers/test_builder/container_manager.rb
@@ -52,6 +52,22 @@ class TestBuilder::ContainerManager < ::TestBuilder
     add_common_default_values
   end
 
+  def container_group_tags
+    add_properties(
+      :model_class => ContainerGroupTag,
+      :manager_ref => %i(container_group tag),
+    )
+  end
+
+  def tags
+    add_properties(
+      :model_class => Tag,
+      :manager_ref => %i(name value),
+    )
+    add_default_values(:namespace => "openshift")
+    add_common_default_values
+  end
+
   def containers
     add_properties(
       :model_class            => Container,
@@ -80,7 +96,6 @@ class TestBuilder::ContainerManager < ::TestBuilder
 
   def container_build_pods
     add_properties(
-      # TODO: (bpaskinc) convert namespace column -> container_project_id?
       :manager_ref    => %i(namespace name),
       :secondary_refs => {:by_namespace_and_name => %i(namespace name)},
       :model_class    => ContainerBuildPod,

--- a/spec/helpers/test_persister/containers.rb
+++ b/spec/helpers/test_persister/containers.rb
@@ -5,12 +5,14 @@ class TestPersister::Containers < ::TestPersister
     %i(containers
        container_build_pods
        container_groups
+       container_group_tags
        container_image_registries
        container_images
        container_nodes
        container_projects
        container_replicators
-       nested_containers).each do |name|
+       nested_containers
+       tags).each do |name|
 
       add_collection(name, container)
     end

--- a/spec/models/container_group.rb
+++ b/spec/models/container_group.rb
@@ -6,6 +6,8 @@ class ContainerGroup < ActiveRecord::Base
   has_many :containers, :dependent => :destroy
   has_many :nested_containers, :dependent => :destroy
   has_many :container_images, -> { distinct }, :through => :containers
+  has_many :container_group_tags
+  has_many :tags, :through => :container_group_tags
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_node
   belongs_to :container_replicator

--- a/spec/models/container_group_tag.rb
+++ b/spec/models/container_group_tag.rb
@@ -1,0 +1,4 @@
+class ContainerGroupTag < ActiveRecord::Base
+  belongs_to :container_group
+  belongs_to :tag
+end

--- a/spec/models/manageiq/providers/container_manager.rb
+++ b/spec/models/manageiq/providers/container_manager.rb
@@ -5,6 +5,7 @@ module ManageIQ
     class ContainerManager < ManageIQ::Providers::BaseManager
       has_many :container_nodes, -> { active }, :foreign_key => :ems_id
       has_many :container_groups, -> { active }, :foreign_key => :ems_id
+      has_many :container_group_tags, :through => :container_groups
       has_many :container_replicators, :foreign_key => :ems_id, :dependent => :destroy
       has_many :containers, -> { active }, :foreign_key => :ems_id
       has_many :container_build_pods, :foreign_key => :ems_id, :dependent => :destroy
@@ -13,6 +14,8 @@ module ManageIQ
       has_many :container_images, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
 
       has_many :nested_containers, :through => :container_groups
+
+      has_many :tags, :foreign_key => :ems_id
 
       # Archived and active entities to destroy when the container manager is deleted
       has_many :all_containers, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "Container"

--- a/spec/models/tag.rb
+++ b/spec/models/tag.rb
@@ -1,0 +1,4 @@
+class Tag < ActiveRecord::Base
+  has_many :container_group_tags
+  has_many :container_groups, :through => :container_group_tags
+end

--- a/spec/persister/targeted_refresh_spec_helper.rb
+++ b/spec/persister/targeted_refresh_spec_helper.rb
@@ -34,12 +34,14 @@ module TargetedRefreshSpecHelper
   def base_inventory_counts_containers
     {
       :container_group          => 0,
+      :container_group_tags     => 0,
       :container_node           => 0,
       :container_project        => 0,
       :container_replicator     => 0,
       :container                => 0,
       :container_image          => 0,
       :container_image_registry => 0,
+      :tags                     => 0
     }
   end
 
@@ -79,12 +81,14 @@ module TargetedRefreshSpecHelper
   def assert_containers_table_counts(expected_table_counts)
     actual = {
       :container_group          => ContainerGroup.count,
+      :container_group_tags     => ContainerGroupTag.count,
       :container_node           => ContainerNode.count,
       :container_project        => ContainerProject.count,
       :container_replicator     => ContainerReplicator.count,
       :container                => Container.count,
       :container_image          => ContainerImage.count,
       :container_image_registry => ContainerImageRegistry.count,
+      :tags                     => Tag.count,
     }
     expect(actual).to eq expected_table_counts
   end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -611,6 +611,26 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.index ["type"], name: "index_container_groups_on_type", using: :btree
   end
 
+  create_table "tags", id: :bigserial, force: :cascade do |t|
+    t.bigint "ems_id", null: false
+    t.string "name", null: false
+    t.string "namespace", default: "", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.string "value", default: "", null: false
+    t.index ["ems_id", "namespace", "name", "value"], name: "index_tags_on_ems_id_and_namespace_and_name_and_value", unique: true
+  end
+
+  create_table "container_group_tags", id: :serial, force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "container_group_id", null: false
+    t.index ["container_group_id", "tag_id"], name: "uniq_index_on_container_group_id_tag_id", unique: true
+    t.index ["tag_id"], name: "index_container_group_tags_on_tag_id"
+  end
+
+  add_foreign_key "container_group_tags", "container_groups", on_delete: :cascade
+  add_foreign_key "container_group_tags", "tags", on_delete: :cascade
+
   create_table "containers", id: :bigserial, force: :cascade do |t|
     t.string   "ems_ref"
     t.integer  "restart_count"
@@ -801,10 +821,10 @@ ActiveRecord::Schema.define(version: 20180906121026) do
 
   create_table "container_build_pods", id: :bigserial, force: :cascade do |t|
     t.string   "ems_ref"
-    t.string   "name"
+    t.string   "name", null: false
     t.datetime "ems_created_on"
     t.string   "resource_version_string"
-    t.string   "namespace"
+    t.string   "namespace", null: false
     t.string   "message"
     t.string   "phase"
     t.string   "reason"
@@ -816,6 +836,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.bigint   "ems_id"
     t.datetime "created_on"
     t.index ["ems_id", "ems_ref"], name: "index_container_build_pods_on_ems_id_and_ems_ref", unique: true, using: :btree
+    t.index ["ems_id", "namespace", "name"], name: "index_container_build_pods_on_ems_id_and_name", unique: true, using: :btree
     t.index ["ems_id"], name: "index_container_build_pods_on_ems_id", using: :btree
   end
 


### PR DESCRIPTION
We will allow to precreate record with empty string value, but
not yet with nil values. Since nil value will require change
in batching and DB check for not null and alternative unique
indexes allowing null value. And adding specs for this.