### PR TITLE
Remove targeted option

### DIFF
--- a/lib/inventory_refresh/inventory_collection/builder.rb
+++ b/lib/inventory_refresh/inventory_collection/builder.rb
@@ -12,7 +12,7 @@ module InventoryRefresh
            manager_ref                  manager_ref_allowed_nil
            model_class                  name                    parent
            retention_strategy           strategy
-           secondary_refs               targeted
+           secondary_refs
            update_only                  use_ar_object
            assert_graph_integrity).to_set
       end

--- a/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
+++ b/lib/inventory_refresh/inventory_collection/helpers/initialize_helper.rb
@@ -92,17 +92,13 @@ module InventoryRefresh
         # @param use_ar_object [Boolean] True or False. Whether we need to initialize AR object as part of the saving
         #        it's needed if the model have special setters, serialize of columns, etc. This setting is relevant only
         #        for the batch saver strategy.
-        # @param targeted [Boolean] True if the collection is targeted, going forward, everything will be targeted
-        def init_flags(complete, create_only, check_changed,
-                       update_only, use_ar_object, targeted,
-                       assert_graph_integrity)
+        def init_flags(complete, create_only, check_changed, update_only, use_ar_object, assert_graph_integrity)
           @complete               = complete.nil? ? true : complete
           @create_only            = create_only.nil? ? false : create_only
           @check_changed          = check_changed.nil? ? true : check_changed
           @saved                  = false
           @update_only            = update_only.nil? ? false : update_only
           @use_ar_object          = use_ar_object || false
-          @targeted               = !!targeted
           @assert_graph_integrity = assert_graph_integrity.nil? ? true : assert_graph_integrity
         end
 
@@ -163,14 +159,16 @@ module InventoryRefresh
         #        doing create/update/delete.
         #
         #        Example:
-        #        for a targeted refresh, we want to delete/update/create only a list of vms specified with a list of
-        #        ems_refs:
-        #            :arel => manager.vms.where(:ems_ref => manager_refs)
-        #        Then we want to do the same for the hardwares of only those vms:
-        #             :arel => manager.hardwares.joins(:vm_or_template).where(
-        #               'vms' => {:ems_ref => manager_refs}
-        #             )
-        #        And etc. for the other Vm related records.
+        #          add_collection(:cross_link_vms) do |builder|
+        #            builder.add_properties(
+        #              :arel        => Vm.where(:tenant => manager.tenant),
+        #              :association => nil,
+        #              :model_class => Vm,
+        #              :name        => :cross_link_vms,
+        #              :manager_ref => [:uid_ems],
+        #              :strategy    => :local_db_find_references,
+        #            )
+        #          end
         def init_arels(arel)
           @arel = arel
         end

--- a/lib/inventory_refresh/inventory_collection/helpers/questions_helper.rb
+++ b/lib/inventory_refresh/inventory_collection/helpers/questions_helper.rb
@@ -81,17 +81,11 @@ module InventoryRefresh
           data_collection_finalized
         end
 
-        # @return [Boolean] true is processing of this InventoryCollection will be in targeted mode
-        def targeted?
-          targeted
-        end
-
         # True if processing of this InventoryCollection object would lead to no operations. Then we use this marker to
         # stop processing of the InventoryCollector object very soon, to avoid a lot of unnecessary Db queries, etc.
         #
         # @return [Boolean] true if processing of this InventoryCollection object would lead to no operations.
         def noop?
-          # If this InventoryCollection doesn't do anything. it can easily happen for targeted/batched strategies.
           data.blank? && custom_save_block.nil? && skeletal_primary_index.blank?
         end
       end

--- a/lib/inventory_refresh/inventory_collection/scanner.rb
+++ b/lib/inventory_refresh/inventory_collection/scanner.rb
@@ -41,7 +41,6 @@ module InventoryRefresh
       # Boolean helpers the scanner uses from the :inventory_collection
       delegate :inventory_object_lazy?,
                :inventory_object?,
-               :targeted?,
                :to => :inventory_collection
 
       # Methods the scanner uses from the :inventory_collection
@@ -58,7 +57,6 @@ module InventoryRefresh
                :custom_save_block,
                :data_collection_finalized=,
                :dependency_attributes,
-               :targeted?,
                :parent,
                :references,
                :transitive_dependency_attributes,

--- a/lib/inventory_refresh/inventory_object_lazy.rb
+++ b/lib/inventory_refresh/inventory_object_lazy.rb
@@ -100,7 +100,7 @@ module InventoryRefresh
 
     private
 
-    delegate :parallel_safe?, :saved?, :saver_strategy, :skeletal_primary_index, :targeted?, :to => :inventory_collection
+    delegate :parallel_safe?, :saved?, :saver_strategy, :skeletal_primary_index, :to => :inventory_collection
     delegate :nested_secondary_index?, :primary?, :full_reference, :keys, :primary?, :to => :reference
 
     attr_writer :reference

--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -214,11 +214,6 @@ module InventoryRefresh
       nil
     end
 
-    # Persisters for targeted refresh can override to true
-    def targeted?
-      false
-    end
-
     def assert_graph_integrity?
       false
     end
@@ -227,7 +222,6 @@ module InventoryRefresh
     def shared_options
       {
         :strategy               => strategy,
-        :targeted               => targeted?,
         :parent                 => manager.presence,
         :assert_graph_integrity => assert_graph_integrity?,
       }

--- a/lib/inventory_refresh/save_collection/saver/base.rb
+++ b/lib/inventory_refresh/save_collection/saver/base.rb
@@ -28,6 +28,7 @@ module InventoryRefresh::SaveCollection
 
         # Right now ApplicationRecordIterator in association is used for targeted refresh. Given the small amount of
         # records flowing through there, we probably don't need to optimize that association to fetch a pure SQL.
+        # TODO(lsmola) since we save everything through targeted mode, we want to optimize this
         @pure_sql_records_fetching = !inventory_collection.use_ar_object? && !@association.kind_of?(InventoryRefresh::ApplicationRecordIterator)
 
         @batch_size_for_persisting = inventory_collection.batch_size_pure_sql
@@ -73,9 +74,6 @@ module InventoryRefresh::SaveCollection
 
       # Saves the InventoryCollection
       def save_inventory_collection!
-        # If we have a targeted InventoryCollection that wouldn't do anything, quickly skip it
-        return if inventory_collection.noop?
-
         # Create/Update/Archive/Delete records based on InventoryCollection data and scope
         save!(association)
       end
@@ -130,7 +128,7 @@ module InventoryRefresh::SaveCollection
 
       # @return [String] a string for logging purposes
       def inventory_collection_details
-        "strategy: #{inventory_collection.strategy}, saver_strategy: #{inventory_collection.saver_strategy}, targeted: #{inventory_collection.targeted?}"
+        "strategy: #{inventory_collection.strategy}, saver_strategy: #{inventory_collection.saver_strategy}"
       end
 
       # Check if relation provided is distinct, i.e. the relation should not return the same primary key value twice.

--- a/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -55,6 +55,8 @@ module InventoryRefresh::SaveCollection
           # Building fast iterator doing pure SQL query and therefore avoiding redundant creation of AR objects. The
           # iterator responds to find_in_batches, so it acts like the AR relation. For targeted refresh, the association
           # can already be ApplicationRecordIterator, so we will skip that.
+          # TODO(lsmola) Since everything is targeted now, we want to probably delete this branch and make iterator to
+          # do pure SQL queries, if there will be no .check_changed?
           pure_sql_iterator = lambda do |&block|
             primary_key_offset = nil
             loop do
@@ -176,14 +178,7 @@ module InventoryRefresh::SaveCollection
         records_for_destroy = []
         indexed_inventory_objects = {}
 
-        # TODO(lsmola) remove when switching to only targeted mode
-        attrs = if records_batch_iterator.kind_of?(InventoryRefresh::ApplicationRecordIterator)
-                  {:batch_size => batch_size, :attributes_index => attributes_index}
-                else
-                  {:batch_size => batch_size}
-                end
-
-        records_batch_iterator.find_in_batches(attrs) do |batch|
+        records_batch_iterator.find_in_batches(:batch_size => batch_size, :attributes_index => attributes_index) do |batch|
           update_time = time_now
 
           batch.each do |record|
@@ -292,10 +287,7 @@ module InventoryRefresh::SaveCollection
       def db_columns_index(record, pure_sql: false)
         # Incoming values are in SQL string form.
         # TODO(lsmola) unify this behavior with object_index_with_keys method in InventoryCollection
-        # TODO(lsmola) maybe we can drop the whole pure sql fetching, since everything will be targeted refresh
         # with streaming refresh? Maybe just metrics and events will not be, but those should be upsert only
-        # TODO(lsmola) taking ^ in account, we can't drop pure sql, since that is returned by batch insert and
-        # update queries
         unique_index_keys_to_s.map do |attribute|
           value = if pure_sql
                     record[attribute]

--- a/spec/helpers/test_persister/cloud.rb
+++ b/spec/helpers/test_persister/cloud.rb
@@ -54,10 +54,6 @@ class TestPersister::Cloud < ::TestPersister
     end
   end
 
-  def targeted?
-    true
-  end
-
   def strategy
     :local_db_find_missing_references
   end

--- a/spec/helpers/test_persister/containers.rb
+++ b/spec/helpers/test_persister/containers.rb
@@ -20,10 +20,6 @@ class TestPersister::Containers < ::TestPersister
 
   protected
 
-  def targeted?
-    true
-  end
-
   def strategy
     :local_db_find_missing_references
   end

--- a/spec/persister/builder_spec.rb
+++ b/spec/persister/builder_spec.rb
@@ -59,9 +59,9 @@ describe InventoryRefresh::InventoryCollection::Builder do
   # --- shared properties ---
 
   it 'applies shared properties' do
-    data = described_class.prepare_data(:tmp, persister_class, :shared_properties => {:targeted => true}).to_hash
+    data = described_class.prepare_data(:tmp, persister_class, :shared_properties => {:update_only => true}).to_hash
 
-    expect(data[:targeted]).to be_truthy
+    expect(data[:update_only]).to be_truthy
   end
 
   it "doesn't overwrite defined properties by shared properties" do

--- a/spec/save_inventory/saver_strategies_spec.rb
+++ b/spec/save_inventory/saver_strategies_spec.rb
@@ -131,6 +131,8 @@ describe InventoryRefresh::SaveInventory do
       end
 
       it "saves records correctly with complex interconnection" do
+        time_now = Time.now.utc
+
         # Setup InventoryCollections
         miq_templates_init_data(inventory_collection_options(options))
 
@@ -232,20 +234,20 @@ describe InventoryRefresh::SaveInventory do
 
         # Check ICs stats
         expect(@persister.vms.created_records).to match_array(record_stats([@vm3, @vm31]))
-        expect(@persister.vms.deleted_records).to match_array(record_stats([@vm1, @vm12, @vm4]))
+        expect(@persister.vms.deleted_records).to match_array(record_stats([]))
         expect(@persister.vms.updated_records).to match_array(record_stats([@vm2]))
 
         expect(@persister.network_ports.created_records).to match_array(record_stats([@network_port3]))
-        expect(@persister.network_ports.deleted_records).to match_array(record_stats([@network_port2, @network_port4]))
+        expect(@persister.network_ports.deleted_records).to match_array(record_stats([]))
         expect(@persister.network_ports.updated_records).to match_array(record_stats([@network_port1, @network_port12]))
 
         expect(@persister.hardwares.created_records).to match_array(record_stats([@vm3.hardware, @vm31.hardware]))
         # We don't see hardwares that were disconnected as a part of Vm or Template
-        expect(@persister.hardwares.deleted_records).to match_array(record_stats([@image_hardware2, @image_hardware3]))
+        expect(@persister.hardwares.deleted_records).to match_array(record_stats([]))
         expect(@persister.hardwares.updated_records).to match_array(record_stats([@hardware2]))
 
         expect(@persister.miq_templates.created_records).to match_array(record_stats([]))
-        expect(@persister.miq_templates.deleted_records).to match_array(record_stats([@image1]))
+        expect(@persister.miq_templates.deleted_records).to match_array(record_stats([]))
         expect(@persister.miq_templates.updated_records).to match_array(record_stats([@image2, @image3]))
 
         # Check the changed timestamps
@@ -310,14 +312,14 @@ describe InventoryRefresh::SaveInventory do
           {:vm_or_template_id => @image2.id, :guest_os => "linux_generic_2"},
           {:vm_or_template_id => @image3.id, :guest_os => "linux_generic_3"},
           {:vm_or_template_id => @vm1.id, :guest_os => "linux_generic_1"},
-          {:vm_or_template_id => @vm2.id, :guest_os => nil},
+          {:vm_or_template_id => @vm2.id, :guest_os => "linux_generic_1"},
           {:vm_or_template_id => @vm12.id, :guest_os => "linux_generic_1"},
           {:vm_or_template_id => @vm3.id, :guest_os => "linux_generic_2"},
           {:vm_or_template_id => @vm31.id, :guest_os => "linux_generic_2"}
         )
 
         assert_all_records_match_hashes(
-          [NetworkPort.active],
+          [NetworkPort.active.where(:last_seen_at => time_now..DateTime::Infinity.new)],
           {
             :id          => @network_port1.id,
             :ems_id      => @ems.network_manager.id,

--- a/spec/save_inventory/strategies_and_references_spec.rb
+++ b/spec/save_inventory/strategies_and_references_spec.rb
@@ -303,15 +303,14 @@ describe InventoryRefresh::SaveInventory do
         expect(@network_port1.device).to eq @vm3
         expect(@network_port1.name).to eq "vm_name_3"
         expect(@network_port12.device).to eq @vm2
-        # Vm4 name was not found, because @vm4 got disconnected and no longer can be found in ems.vms
-        expect(@network_port12.name).to eq "default_name"
+        expect(@network_port12.name).to eq "vm_name_4"
         expect(@network_port3.device).to eq @vm1
         expect(@network_port3.name).to eq "vm_name_1"
         expect(@vm3.hardware.guest_os).to eq "linux_generic_2"
         # We don't support :key pointing to a has_many, so it default to []
         expect(@vm31.hardware).to be_nil
-        # Check Vm4 was disconnected
-        expect(@vm4.archived_at).not_to be_nil
+        # We don't archive anything until we explicitly call sweep
+        expect(@vm4.archived_at).to be_nil
       end
     end
   end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -9,6 +9,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string "ems_ref"
     t.string "type"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_availability_zone_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_availability_zones_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_availability_zones_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["ems_id"], name: "index_availability_zones_on_ems_id", using: :btree
@@ -26,6 +28,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "type"
     t.bigint   "parent_id"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_cloud_tenants_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_cloud_tenants_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_cloud_tenants_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["type"], name: "index_cloud_tenants_on_type", using: :btree
@@ -112,6 +116,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.bigint   "source_region_id"
     t.bigint   "subscription_id"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_vms_on_last_seen_at", using: :btree
     t.index ["availability_zone_id"], name: "index_vms_on_availability_zone_id", using: :btree
     t.index ["evm_owner_id"], name: "index_vms_on_evm_owner_id", using: :btree
     t.index ["flavor_id"], name: "index_vms_on_flavor_id", using: :btree
@@ -169,6 +175,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string  "firmware_type"
     t.bigint  "canister_id"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_hardwares_on_last_seen_at", using: :btree
     t.index ["computer_system_id"], name: "index_hardwares_on_computer_system_id", using: :btree
     t.index ["host_id"], name: "index_hardwares_on_host_id", using: :btree
     t.index ["vm_or_template_id"], name: "index_hardwares_on_vm_or_template_id", unique: true, using: :btree
@@ -199,6 +207,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.bigint   "storage_profile_id"
     t.boolean  "bootable"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_disks_on_last_seen_at", using: :btree
     t.index ["hardware_id", "device_name"], name: "index_disks_on_hardware_id_and_device_name", unique: true, using: :btree
     t.index ["device_type"], name: "index_disks_on_device_type", using: :btree
     t.index ["storage_id"], name: "index_disks_on_storage_id", using: :btree
@@ -328,6 +338,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.bigint  "swap_disk_size"
     t.boolean "publicly_available"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_flavors_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_flavors_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_flavors_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["ems_id", "name"], name: "index_flavors_on_ems_id_and_name", unique: true, using: :btree
@@ -373,6 +385,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "maintenance_reason"
     t.bigint   "physical_server_id"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_hosts_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_hosts_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_hosts_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["availability_zone_id"], name: "index_hosts_on_availability_zone_id", using: :btree
@@ -400,6 +414,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "domain"
     t.string   "ipv6address"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_networks_on_last_seen_at", using: :btree
     t.index ["hardware_id", "description"], name: "index_networks_on_hardware_id_and_description", unique: true, using: :btree
     t.index ["device_id"], name: "index_networks_on_device_id", using: :btree
   end
@@ -424,6 +440,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.text    "extra_attributes"
     t.string  "source"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_network_ports_on_last_seen_at", using: :btree
     t.index ["cloud_tenant_id"], name: "index_network_ports_on_cloud_tenant_id", using: :btree
     t.index ["device_id", "device_type"], name: "index_network_ports_on_device_id_and_device_type", using: :btree
     t.index ["type"], name: "index_network_ports_on_type", using: :btree
@@ -445,6 +463,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.datetime "start_time"
     t.datetime "finish_time"
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_orchestration_stack_resources_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_stacks_res_on_archived_at", using: :btree
     t.index ["stack_id", "ems_ref"], name: "index_stacks_res_on_stack_id_and_ems_ref", unique: true, using: :btree
     t.index ["stack_id"], name: "index_orchestration_stack_resources_on_stack_id", using: :btree
@@ -477,6 +497,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.text     "hosts",                        array: true
     t.datetime "archived_at"
     t.bigint "parent_id"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_orchestration_stacks_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_stacks_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_stacks_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index "ancestry varchar_pattern_ops", name: "index_orchestration_stacks_on_ancestry_vpo", using: :btree
@@ -509,7 +531,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "ems_compliance_name"
     t.string   "ems_compliance_status"
     t.bigint   "physical_chassis_id"
-
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_physical_servers_on_last_seen_at", using: :btree
     t.datetime "archived_at"
     t.index ["archived_at"], name: "index_physical_servers_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_physical_servers_on_ems_id_and_ems_ref", unique: true, using: :btree
@@ -538,7 +561,6 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.bigint   "old_ems_id"
     t.bigint   "old_container_project_id"
     t.datetime "updated_on"
-    t.datetime "last_seen_at"
     t.datetime "resource_timestamp"
     t.jsonb    "resource_timestamps", default: {}
     t.datetime "resource_timestamps_max"
@@ -546,6 +568,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.jsonb    "resource_counters", default: {}
     t.integer  "resource_counters_max"
     t.string   "resource_version"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_container_groups_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_container_groups_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_container_groups_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["ems_id"], name: "index_container_groups_on_ems_id", using: :btree
@@ -559,6 +583,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.text "description"
     t.datetime "created_at", null: false
     t.string "value", default: "", null: false
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_tags_on_last_seen_at", using: :btree
     t.index ["ems_id", "namespace", "name", "value"], name: "index_tags_on_ems_id_and_namespace_and_name_and_value", unique: true
   end
 
@@ -612,10 +638,11 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "capabilities_add"
     t.string   "capabilities_drop"
     t.text     "command"
-    t.datetime "last_seen_at"
     t.datetime "resource_timestamp"
     t.jsonb    "resource_timestamps", default: {}
     t.datetime "resource_timestamps_max"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_containers_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_containers_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_containers_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["type"], name: "index_containers_on_type", using: :btree
@@ -660,10 +687,11 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "capabilities_add"
     t.string   "capabilities_drop"
     t.text     "command"
-    t.datetime "last_seen_at"
     t.datetime "resource_timestamp"
     t.jsonb    "resource_timestamps", default: {}
     t.datetime "resource_timestamps_max"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_nested_containers_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_nested_containers_on_archived_at", using: :btree
     t.index ["container_group_id", "name"], name: "index_nested_containers_uniq", unique: true, using: :btree
     t.index ["type"], name: "index_nested_containers_on_type", using: :btree
@@ -700,6 +728,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.datetime "archived_at"
     t.string   "type"
     t.jsonb    "timestamps",                  default: {}
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_container_images_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_container_images_on_archived_at", using: :btree
     t.index ["ems_id", "image_ref"], name: "index_container_images_unique_multi_column", unique: true, using: :btree
     t.index ["ems_id"], name: "index_container_images_on_ems_id", using: :btree
@@ -715,6 +745,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.datetime "created_on"
     t.datetime "archived_at"
     t.bigint   "old_ems_id"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_container_projects_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_container_projects_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_container_projects_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["ems_id"], name: "index_container_projects_on_ems_id", using: :btree
@@ -754,6 +786,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.bigint   "old_ems_id"
     t.datetime "archived_at"
     t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_container_nodes_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_container_nodes_on_archived_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_container_nodes_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["ems_id"], name: "index_container_nodes_on_ems_id", using: :btree
@@ -776,6 +809,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.bigint   "container_build_id"
     t.bigint   "ems_id"
     t.datetime "created_on"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_container_build_pods_on_last_seen_at", using: :btree
     t.index ["ems_id", "ems_ref"], name: "index_container_build_pods_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["ems_id", "namespace", "name"], name: "index_container_build_pods_on_ems_id_and_name", unique: true, using: :btree
     t.index ["ems_id"], name: "index_container_build_pods_on_ems_id", using: :btree
@@ -789,6 +824,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_source_regions_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_source_regions_on_archived_at"
     t.index ["ems_id", "ems_ref"], name: "index_source_regions_on_ems_id_and_ems_ref", unique: true
     t.index ["ems_id"], name: "index_source_regions_on_ems_id"
@@ -801,6 +838,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "archived_at"
+    t.datetime "last_seen_at"
+    t.index ["last_seen_at"], name: "index_subscriptions_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_subscriptions_on_archived_at"
     t.index ["ems_id", "ems_ref"], name: "index_subscriptions_on_ems_id_and_ems_ref", unique: true
     t.index ["ems_id"], name: "index_subscriptions_on_ems_id"


### PR DESCRIPTION
There is no full refresh anymore (because it rises unbounded in memory), so everything is in targeted mode by default.

Depends on:
- [x] https://github.com/ManageIQ/inventory_refresh/pull/73