### PR TITLE
Simplify the records iterator

### DIFF
--- a/lib/inventory_refresh/application_record_iterator.rb
+++ b/lib/inventory_refresh/application_record_iterator.rb
@@ -1,6 +1,6 @@
 module InventoryRefresh
   class ApplicationRecordIterator
-    attr_reader :inventory_collection, :manager_uuids_set, :iterator, :query
+    attr_reader :inventory_collection
 
     # An iterator that can fetch batches of the AR objects based on a set of attribute_indexes
     #

--- a/lib/inventory_refresh/save_collection/saver/base.rb
+++ b/lib/inventory_refresh/save_collection/saver/base.rb
@@ -29,7 +29,7 @@ module InventoryRefresh::SaveCollection
         @batch_size_for_persisting = inventory_collection.batch_size_pure_sql
         @batch_size                = inventory_collection.use_ar_object? ? @batch_size_for_persisting : inventory_collection.batch_size
 
-        @record_key_method   = :ar_record_key # inventory_collection.use_ar_object? ? :ar_record_key : :pure_sql_record_key
+        @record_key_method   = inventory_collection.pure_sql_record_fetching? ? :pure_sql_record_key : :ar_record_key
         @select_keys_indexes = @select_keys.each_with_object({}).with_index { |(key, obj), index| obj[key.to_s] = index }
         @pg_types            = @model_class.attribute_names.each_with_object({}) do |key, obj|
           obj[key.to_sym] = inventory_collection.model_class.columns_hash[key]

--- a/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -176,9 +176,9 @@ module InventoryRefresh::SaveCollection
                                                    [:resource_counter, :resource_counters_max]
                                                  end
 
-                next if skeletonize_or_skip_record(record_key(record, version_attr),
+                next if skeletonize_or_skip_record(record_key(record, version_attr.to_s),
                                                    hash[version_attr],
-                                                   record_key(record, max_version_attr),
+                                                   record_key(record, max_version_attr.to_s),
                                                    inventory_object)
               end
 

--- a/lib/inventory_refresh/save_collection/saver/partial_upsert_helper.rb
+++ b/lib/inventory_refresh/save_collection/saver/partial_upsert_helper.rb
@@ -201,6 +201,18 @@ module InventoryRefresh::SaveCollection
       end
 
       def skeletonize_or_skip_record(record_version, hash_version, record_versions_max, inventory_object)
+        # The hash version is string, the record_version and record_versions_max will be time object, ruby will
+        # automatically cast it, so we can compare them
+        if record_version.kind_of?(String)
+          record_version = Time.use_zone('UTC') { Time.zone.parse(record_version) }.to_s
+          record_versions_max = Time.use_zone('UTC') { Time.zone.parse(record_versions_max) }.to_s if record_versions_max
+        elsif record_version.kind_of?(Time)
+          record_version = record_version.to_s
+          record_versions_max = record_versions_max.to_s if record_versions_max
+        end
+
+        hash_version = hash_version.to_s if hash_version.kind_of?(Time)
+
         # Skip updating this record, because it is old
         return true if record_version && hash_version && record_version >= hash_version
 

--- a/lib/inventory_refresh/save_collection/saver/partial_upsert_helper.rb
+++ b/lib/inventory_refresh/save_collection/saver/partial_upsert_helper.rb
@@ -200,29 +200,24 @@ module InventoryRefresh::SaveCollection
         )
       end
 
-      def skeletonize_or_skip_record(record_version, hash_version, record_versions_max, inventory_object)
+      def comparable_timestamp(timestamp)
         # Lets cast all timestamps to to_f, rounding the time comparing precision to miliseconds, that should be
         # enough, since we are the ones setting the record version in collector. Otherwise we will have hard time with
         # doing equality, since the value changes going through DB (DB. cuts it at 5 decimal places)
-        if record_version.kind_of?(String)
-          record_version = Time.use_zone('UTC') { Time.zone.parse(record_version) }.to_f.round(3)
-        elsif record_version.kind_of?(Time)
-          record_version = record_version.in_time_zone('UTC').to_f.round(3)
-        end
 
-        if record_versions_max
-          if record_versions_max.kind_of?(String)
-            record_versions_max = Time.use_zone('UTC') { Time.zone.parse(record_versions_max) }.to_f.round(3)
-          elsif record_versions_max.kind_of?(Time)
-            record_versions_max = record_versions_max.in_time_zone('UTC').to_f.round(3)
-          end
+        if timestamp.kind_of?(String)
+          Time.use_zone('UTC') { Time.zone.parse(timestamp) }.to_f.round(3)
+        elsif timestamp.kind_of?(Time)
+          timestamp.in_time_zone('UTC').to_f.round(3)
+        else
+          timestamp
         end
+      end
 
-        if hash_version.kind_of?(String)
-          hash_version = Time.use_zone('UTC') { Time.zone.parse(hash_version) }.to_f.round(3)
-        elsif hash_version.kind_of?(Time)
-          hash_version = hash_version.in_time_zone('UTC').to_f.round(3)
-        end
+      def skeletonize_or_skip_record(record_version, hash_version, record_versions_max, inventory_object)
+        record_version      = comparable_timestamp(record_version)
+        record_versions_max = comparable_timestamp(record_versions_max) if record_versions_max
+        hash_version        = comparable_timestamp(hash_version)
 
         # Skip updating this record, because it is old
         return true if record_version && hash_version && record_version >= hash_version

--- a/spec/persister/parallel_saving_spec.rb
+++ b/spec/persister/parallel_saving_spec.rb
@@ -12,18 +12,34 @@ describe InventoryRefresh::Persister do
   end
 
   [{
-    :upsert_only            => true,
-    :parallel_saving_column => "resource_counter",
-  }, {
-    :upsert_only            => false,
-    :parallel_saving_column => "resource_counter",
-  }, {
-    :upsert_only            => true,
-    :parallel_saving_column => "resource_timestamp",
-  }, {
-    :upsert_only            => false,
-    :parallel_saving_column => "resource_timestamp",
-  },].each do |settings|
+     :upsert_only            => true,
+     :parallel_saving_column => "resource_counter",
+   }, {
+     :upsert_only            => false,
+     :parallel_saving_column => "resource_counter",
+   }, {
+     :upsert_only            => true,
+     :parallel_saving_column => "resource_timestamp",
+   }, {
+     :upsert_only            => false,
+     :parallel_saving_column => "resource_timestamp",
+   }, {
+     :upsert_only            => true,
+     :parallel_saving_column => "resource_timestamp",
+     :use_ar_object          => true,
+   }, {
+     :upsert_only            => false,
+     :parallel_saving_column => "resource_timestamp",
+     :use_ar_object          => true,
+   }, {
+     :upsert_only            => true,
+     :parallel_saving_column => "resource_timestamp",
+     :use_ar_object          => false,
+   }, {
+     :upsert_only            => false,
+     :parallel_saving_column => "resource_timestamp",
+     :use_ar_object          => false,
+   }].each do |settings|
     context "with settings #{settings}" do
       before(:each) do
         if settings[:upsert_only]

--- a/spec/persister/sweep_inactive_records_spec.rb
+++ b/spec/persister/sweep_inactive_records_spec.rb
@@ -18,7 +18,7 @@ describe InventoryRefresh::Persister do
           time_now         = Time.now.utc
           time_before      = Time.now.utc - 20.seconds
           time_more_before = Time.now.utc - 40.seconds
-          time_after       = Time.now.utc + 20.seconds
+          _time_after       = Time.now.utc + 20.seconds
 
           cg1  = FactoryBot.create(:container_group, container_group_data(1).merge(:ext_management_system => @ems, :resource_timestamp => time_before))
           cg2 = FactoryBot.create(:container_group, container_group_data(2).merge(:ext_management_system => @ems, :resource_timestamp => time_more_before))
@@ -121,7 +121,7 @@ describe InventoryRefresh::Persister do
           persister.container_groups.build(container_group_data(1).merge(:resource_timestamp => time_before))
           persister.container_groups.build(container_group_data(2).merge(:resource_timestamp => time_before))
           persister.container_groups.build(container_group_data(5).merge(:resource_timestamp => time_before))
-          persister = persist(persister, config)
+          _persister = persist(persister, config)
 
           # Refresh second part and mark :last_seen_at
           persister                         = create_containers_persister(:retention_strategy => "archive")
@@ -192,7 +192,7 @@ describe InventoryRefresh::Persister do
           persister.container_groups.build(container_group_data(1).merge(:resource_timestamp => time_before))
           persister.container_groups.build(container_group_data(2).merge(:resource_timestamp => time_before))
           persister.container_groups.build(container_group_data(5).merge(:resource_timestamp => time_before))
-          persister = persist(persister, config)
+          _persister = persist(persister, config)
 
           ################################################################################################################
           # Refresh second part
@@ -201,7 +201,7 @@ describe InventoryRefresh::Persister do
           persister.refresh_state_part_uuid = part2_uuid
 
           persister.container_groups.build(container_group_data(6).merge(:resource_timestamp => time_before))
-          persister = persist(persister, config)
+          _persister = persist(persister, config)
 
           ################################################################################################################
           # Sweeping step. Send persister with total_parts = XY, that will cause sweeping all tables having :last_seen_on
@@ -245,7 +245,7 @@ describe InventoryRefresh::Persister do
             )
           )
 
-          persister = persist(persister, config)
+          _persister = persist(persister, config)
 
           ################################################################################################################
           # Sweeping step.
@@ -338,7 +338,7 @@ describe InventoryRefresh::Persister do
             )
           )
 
-          persister = persist(persister, config)
+          _persister = persist(persister, config)
 
           ################################################################################################################
           # Refresh second part
@@ -353,7 +353,7 @@ describe InventoryRefresh::Persister do
             )
           )
 
-          persister = persist(persister, config)
+          _persister = persist(persister, config)
 
           ################################################################################################################
           # Sweeping step. Send persister with total_parts = XY, that will cause sweeping all tables having :last_seen_on
@@ -488,10 +488,9 @@ describe InventoryRefresh::Persister do
       def persist(persister, config)
         if config[:serialize]
           persister = persister.class.from_json(persister.to_json, @ems)
-          persister.persist!
-        else
-          persister.persist!
         end
+        persister.persist!
+
         persister
       end
 

--- a/spec/persister/sweep_inactive_records_spec.rb
+++ b/spec/persister/sweep_inactive_records_spec.rb
@@ -75,7 +75,6 @@ describe InventoryRefresh::Persister do
           )
 
           # Send persister with total_parts = XY, that will cause sweeping all tables having :last_seen_on column
-          # Send persister with total_parts = XY, that will cause sweeping all tables having :last_seen_on column
           persister.sweep_scope = ["container_groups", "container_nodes"]
           sweep(persister, time_now, config)
 

--- a/spec/persister/test_collector.rb
+++ b/spec/persister/test_collector.rb
@@ -5,7 +5,7 @@ class TestCollector
     def generate_batches_of_partial_container_group_data(ems_name:, version:, settings:, batch_size: 4, index_start: 0,
                                                          persister: nil, resource_version: nil)
       ems = ExtManagementSystem.find_by(:name => ems_name)
-      persister ||= new_persister(ems)
+      persister ||= new_persister(ems, settings)
 
       (index_start * batch_size..((index_start + 1) * batch_size - 1)).each do |index|
         parse_partial_container_group(index, persister, settings, incremented_counter(settings, version, index),
@@ -18,7 +18,7 @@ class TestCollector
     def generate_batches_of_different_partial_container_group_data(ems_name:, version:, settings:, batch_size: 4,
                                                                    index_start: 0, persister: nil, resource_version: nil)
       ems = ExtManagementSystem.find_by(:name => ems_name)
-      persister ||= new_persister(ems)
+      persister ||= new_persister(ems, settings)
 
       (index_start * batch_size..((index_start + 1) * batch_size - 1)).each do |index|
         parse_another_partial_container_group(index, persister, settings, incremented_counter(settings, version, index),
@@ -31,7 +31,7 @@ class TestCollector
     def generate_batches_of_full_container_group_data(ems_name:, version:, settings:, batch_size: 4, index_start: 0,
                                                       persister: nil, resource_version: nil)
       ems = ExtManagementSystem.find_by(:name => ems_name)
-      persister ||= new_persister(ems)
+      persister ||= new_persister(ems, settings)
 
       (index_start * batch_size..((index_start + 1) * batch_size - 1)).each do |index|
         parse_container_group(index, persister, settings, incremented_counter(settings, version, index), resource_version)
@@ -83,13 +83,19 @@ class TestCollector
 
     def refresh(persister)
       manager = persister.manager
+      use_ar_object = persister.inventory_collections.first.use_ar_object
+
       persister = persister.class.from_json(persister.to_json, manager)
+      # :use_ar_object is not exposed to be serializable, it's taken from Persister class, so it's not changeable
+      # in the runtime.
+      persister.inventory_collections.each { |x| x.instance_variable_set(:@use_ar_object, use_ar_object) }
+
       persister.persist!
       persister
     end
 
-    def new_persister(ems)
-      TestPersister::Containers.new(ems, ems)
+    def new_persister(ems, settings)
+      TestPersister::Containers.new(ems, ems, :use_ar_object => settings[:use_ar_object])
     end
 
     def version_col(settings)


### PR DESCRIPTION
Simplify the iterator and allow it to run pure sql fetch (which will cause speedup). Make sure specs with this pass with serialized format too (there was a timestamp comparing change needed to pass all specs, since the pure SQL doesn't cast the timestamp for us)