### PR TITLE
Remove parallel safe option and destroying while update

### DIFF
--- a/lib/inventory_refresh/inventory_collection/helpers/questions_helper.rb
+++ b/lib/inventory_refresh/inventory_collection/helpers/questions_helper.rb
@@ -50,11 +50,6 @@ module InventoryRefresh
           dependencies.all?(&:saved?)
         end
 
-        # @return [Boolean] true if we are using a saver strategy that allows saving in parallel processes
-        def parallel_safe?
-          true
-        end
-
         # @return [Boolean] true if the model_class supports STI
         def supports_sti?
           @supports_sti_cache = model_class.column_names.include?("type") if @supports_sti_cache.nil?

--- a/lib/inventory_refresh/inventory_collection/index/proxy.rb
+++ b/lib/inventory_refresh/inventory_collection/index/proxy.rb
@@ -132,19 +132,13 @@ module InventoryRefresh
 
         delegate :association_to_foreign_key_mapping,
                  :build_stringified_reference,
-                 :parallel_safe?,
                  :strategy,
                  :to => :inventory_collection
 
         attr_reader :all_refs, :data_indexes, :inventory_collection, :primary_ref, :local_db_indexes, :secondary_refs
 
         def find_in_data_or_skeletal_index(reference)
-          if parallel_safe?
-            # With parallel safe strategies, we create skeletal nodes that we can look for
-            data_index_find(reference) || skeletal_index_find(reference)
-          else
-            data_index_find(reference)
-          end
+          data_index_find(reference) || skeletal_index_find(reference)
         end
 
         def skeletal_index_find(reference)

--- a/lib/inventory_refresh/inventory_object_lazy.rb
+++ b/lib/inventory_refresh/inventory_object_lazy.rb
@@ -100,7 +100,7 @@ module InventoryRefresh
 
     private
 
-    delegate :parallel_safe?, :saved?, :saver_strategy, :skeletal_primary_index, :to => :inventory_collection
+    delegate :saved?, :saver_strategy, :skeletal_primary_index, :to => :inventory_collection
     delegate :nested_secondary_index?, :primary?, :full_reference, :keys, :primary?, :to => :reference
 
     attr_writer :reference
@@ -112,10 +112,6 @@ module InventoryRefresh
     #
     # @return [InventoryRefresh::InventoryObject, NilClass] Returns pre-created InventoryObject or nil
     def skeletal_precreate!
-      # We can do skeletal pre-create only for strategies using unique indexes. Since this can build records out of
-      # the given :arel scope, we will always attempt to create the recod, so we need unique index to avoid duplication
-      # of records.
-      return unless parallel_safe?
       # Pre-create only for strategies that will be persisting data, i.e. are not saved already
       return if saved?
       # We can only do skeletal pre-create for primary index reference, since that is needed to create DB unique index

--- a/lib/inventory_refresh/save_collection/saver/sql_helper.rb
+++ b/lib/inventory_refresh/save_collection/saver/sql_helper.rb
@@ -8,9 +8,6 @@ module InventoryRefresh::SaveCollection
     module SqlHelper
       include InventoryRefresh::Logging
 
-      # TODO(lsmola) all below methods should be rewritten to arel, but we need to first extend arel to be able to do
-      # this
-
       extend ActiveSupport::Concern
 
       included do

--- a/lib/inventory_refresh/save_collection/saver/sql_helper_update.rb
+++ b/lib/inventory_refresh/save_collection/saver/sql_helper_update.rb
@@ -27,9 +27,9 @@ module InventoryRefresh::SaveCollection
         all_attribute_keys_array << :id
 
         # If there is not version attribute, the version conditions will be ignored
-        version_attribute = if inventory_collection.parallel_safe? && supports_remote_data_timestamp?(all_attribute_keys)
+        version_attribute = if supports_remote_data_timestamp?(all_attribute_keys)
                               :resource_timestamp
-                            elsif inventory_collection.parallel_safe? && supports_remote_data_version?(all_attribute_keys)
+                            elsif supports_remote_data_version?(all_attribute_keys)
                               :resource_counter
                             end
 
@@ -130,13 +130,9 @@ module InventoryRefresh::SaveCollection
       end
 
       def update_query_returning
-        if inventory_collection.parallel_safe?
-          <<-SQL
-            RETURNING updated_values.#{quote_column_name("id")}, #{unique_index_columns.map { |x| "updated_values.#{quote_column_name(x)}" }.join(",")}
-          SQL
-        else
-          ""
-        end
+        <<-SQL
+          RETURNING updated_values.#{quote_column_name("id")}, #{unique_index_columns.map { |x| "updated_values.#{quote_column_name(x)}" }.join(",")}
+        SQL
       end
     end
   end

--- a/lib/inventory_refresh/save_collection/saver/sql_helper_upsert.rb
+++ b/lib/inventory_refresh/save_collection/saver/sql_helper_upsert.rb
@@ -55,8 +55,6 @@ module InventoryRefresh::SaveCollection
       end
 
       def insert_query_on_conflict_behavior(all_attribute_keys, on_conflict, mode, ignore_cols, column_name)
-        return "" unless inventory_collection.parallel_safe?
-
         insert_query_on_conflict = insert_query_on_conflict_do(on_conflict)
         if on_conflict == :do_update
           insert_query_on_conflict += insert_query_on_conflict_update(all_attribute_keys, mode, ignore_cols, column_name)
@@ -183,16 +181,12 @@ module InventoryRefresh::SaveCollection
       end
 
       def insert_query_returning_timestamps
-        if inventory_collection.parallel_safe?
-          # For upsert, we'll return also created and updated timestamps, so we can recognize what was created and what
-          # updated
-          if inventory_collection.internal_timestamp_columns.present?
-            <<-SQL
-              , #{inventory_collection.internal_timestamp_columns.map { |x| quote_column_name(x) }.join(",")}
-            SQL
-          end
-        else
-          ""
+        # For upsert, we'll return also created and updated timestamps, so we can recognize what was created and what
+        # updated
+        if inventory_collection.internal_timestamp_columns.present?
+          <<-SQL
+            , #{inventory_collection.internal_timestamp_columns.map { |x| quote_column_name(x) }.join(",")}
+          SQL
         end
       end
     end

--- a/lib/inventory_refresh/save_collection/sweeper.rb
+++ b/lib/inventory_refresh/save_collection/sweeper.rb
@@ -27,8 +27,7 @@ module InventoryRefresh::SaveCollection
       end
 
       def sweep_possible?(inventory_collection, scope_set)
-        inventory_collection.supports_column?(:last_seen_at) && inventory_collection.parallel_safe? &&
-          in_scope?(inventory_collection, scope_set)
+        inventory_collection.supports_column?(:last_seen_at) && in_scope?(inventory_collection, scope_set)
       end
 
       def in_scope?(inventory_collection, scope_set)


### PR DESCRIPTION
Everything is parallel safe, so we don't need the check. And we won;t destroy while updating, the only place destroying objects is the sweeping.

Depends on:
- [x] https://github.com/ManageIQ/inventory_refresh/pull/76