### PR TITLE
Update to not log ems.name

### DIFF
--- a/lib/inventory_refresh/save_collection/base.rb
+++ b/lib/inventory_refresh/save_collection/base.rb
@@ -14,7 +14,7 @@ module InventoryRefresh::SaveCollection
         return if skip?(inventory_collection)
 
         logger.debug("----- BEGIN ----- Saving collection #{inventory_collection} of size #{inventory_collection.size} to"\
-                     " the database, for the manager: '#{ems.name}'...")
+                     " the database, for the manager: '#{ems.id}'...")
 
         if inventory_collection.custom_save_block.present?
           logger.debug("Saving collection #{inventory_collection} using a custom save block")
@@ -22,7 +22,7 @@ module InventoryRefresh::SaveCollection
         else
           save_inventory(inventory_collection)
         end
-        logger.debug("----- END ----- Saving collection #{inventory_collection}, for the manager: '#{ems.name}'...Complete")
+        logger.debug("----- END ----- Saving collection #{inventory_collection}, for the manager: '#{ems.id}'...Complete")
         inventory_collection.saved = true
       end
 

--- a/lib/inventory_refresh/save_collection/topological_sort.rb
+++ b/lib/inventory_refresh/save_collection/topological_sort.rb
@@ -17,21 +17,21 @@ module InventoryRefresh::SaveCollection
 
         layers = InventoryRefresh::Graph::TopologicalSort.new(graph).topological_sort
 
-        logger.debug("Saving manager #{ems.name}...")
+        logger.debug("Saving manager #{ems.id}...")
 
-        sorted_graph_log = "Topological sorting of manager #{ems.name} resulted in these layers processable in parallel:\n"
+        sorted_graph_log = "Topological sorting of manager #{ems.id} resulted in these layers processable in parallel:\n"
         sorted_graph_log += graph.to_graphviz(:layers => layers)
         logger.debug(sorted_graph_log)
 
         layers.each_with_index do |layer, index|
-          logger.debug("Saving manager #{ems.name} | Layer #{index}")
+          logger.debug("Saving manager #{ems.id} | Layer #{index}")
           layer.each do |inventory_collection|
             save_inventory_object_inventory(ems, inventory_collection) unless inventory_collection.saved?
           end
-          logger.debug("Saved manager #{ems.name} | Layer #{index}")
+          logger.debug("Saved manager #{ems.id} | Layer #{index}")
         end
 
-        logger.debug("Saving manager #{ems.name}...Complete")
+        logger.debug("Saving manager #{ems.id}...Complete")
       end
     end
   end

--- a/lib/inventory_refresh/save_inventory.rb
+++ b/lib/inventory_refresh/save_inventory.rb
@@ -50,7 +50,7 @@ module InventoryRefresh
       # @param ems [ExtManagementSystem] manager owning the inventory_collections
       # @return [String] helper string for logging
       def log_header(ems)
-        "EMS: [#{ems.name}], id: [#{ems.id}]"
+        "EMS: [#{ems.id}]"
       end
     end
   end

--- a/spec/persister/parallel_saving_spec.rb
+++ b/spec/persister/parallel_saving_spec.rb
@@ -8,7 +8,7 @@ describe InventoryRefresh::Persister do
   include SpecParsedData
 
   before(:each) do
-    @ems = FactoryBot.create(:ems_container, :name => "test_ems")
+    @ems = FactoryBot.create(:ems_container)
   end
 
   [{
@@ -56,7 +56,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => newest_version(settings),
             )
           )
@@ -102,7 +102,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => bigger_newest_version,
             )
           )
@@ -145,7 +145,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings         => settings,
-              :ems_name         => @ems.name,
+              :ems_id           => @ems.id,
               :version          => bigger_newest_version,
               :resource_version => "same_version",
             )
@@ -204,7 +204,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings         => settings,
-              :ems_name         => @ems.name,
+              :ems_id           => @ems.id,
               :version          => bigger_newest_version,
               :resource_version => "different_version_#{i}",
             )
@@ -246,7 +246,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_partial_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => newest_version(settings),
             )
           )
@@ -296,7 +296,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => newest_version(settings),
             )
           )
@@ -324,7 +324,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_partial_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => newest_version(settings),
             )
           )
@@ -367,7 +367,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_partial_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => newest_version(settings),
             )
           )
@@ -408,7 +408,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => newest_version(settings),
             )
           )
@@ -447,7 +447,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_partial_container_group_data(
               :settings         => settings,
-              :ems_name         => @ems.name,
+              :ems_id           => @ems.id,
               :version          => newest_version(settings),
               :resource_version => "same_version",
             )
@@ -490,7 +490,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings         => settings,
-              :ems_name         => @ems.name,
+              :ems_id           => @ems.id,
               :version          => newest_version(settings),
               :resource_version => "same_version",
             )
@@ -535,7 +535,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => newest_version(settings),
             )
           )
@@ -563,7 +563,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_partial_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => bigger_newest_version,
             )
           )
@@ -608,7 +608,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_partial_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => newest_version(settings),
             )
           )
@@ -648,7 +648,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => bigger_newest_version,
             )
           )
@@ -690,7 +690,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_partial_container_group_data(
               :settings => settings,
-              :ems_name => @ems.name,
+              :ems_id   => @ems.id,
               :version  => bigger_newest_version,
             )
           )
@@ -708,7 +708,7 @@ describe InventoryRefresh::Persister do
         2.times do |i|
           persister = TestCollector.generate_batches_of_full_container_group_data(
             :settings    => settings,
-            :ems_name    => @ems.name,
+            :ems_id      => @ems.id,
             :version     => newest_version(settings),
             :index_start => 0,
             :batch_size  => 2
@@ -716,7 +716,7 @@ describe InventoryRefresh::Persister do
 
           TestCollector.generate_batches_of_full_container_group_data(
             :settings    => settings,
-            :ems_name    => @ems.name,
+            :ems_id      => @ems.id,
             :version     => even_bigger_newest_version,
             :persister   => persister,
             :index_start => 1,
@@ -788,13 +788,13 @@ describe InventoryRefresh::Persister do
         2.times do |i|
           persister = TestCollector.generate_batches_of_partial_container_group_data(
             :settings => settings,
-            :ems_name => @ems.name,
+            :ems_id   => @ems.id,
             :version  => newest_version(settings),
           )
 
           TestCollector.generate_batches_of_different_partial_container_group_data(
             :settings    => settings,
-            :ems_name    => @ems.name,
+            :ems_id      => @ems.id,
             :version     => bigger_newest_version,
             :persister   => persister,
             :index_start => 1,
@@ -815,7 +815,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_different_partial_container_group_data(
               :settings    => settings,
-              :ems_name    => @ems.name,
+              :ems_id      => @ems.id,
               :version     => bigger_newest_version,
               :index_start => 0,
               :batch_size  => 2
@@ -857,13 +857,13 @@ describe InventoryRefresh::Persister do
 
         persister = TestCollector.generate_batches_of_partial_container_group_data(
           :settings => settings,
-          :ems_name => @ems.name,
+          :ems_id   => @ems.id,
           :version  => bigger_newest_version,
         )
 
         TestCollector.generate_batches_of_different_partial_container_group_data(
           :settings    => settings,
-          :ems_name    => @ems.name,
+          :ems_id      => @ems.id,
           :version     => newest_version(settings),
           :persister   => persister,
           :index_start => 1,
@@ -923,7 +923,7 @@ describe InventoryRefresh::Persister do
         persister = TestCollector.refresh(
           TestCollector.generate_batches_of_different_partial_container_group_data(
             :settings    => settings,
-            :ems_name    => @ems.name,
+            :ems_id      => @ems.id,
             :version     => newest_version(settings),
             :index_start => 0,
             :batch_size  => 2
@@ -965,13 +965,13 @@ describe InventoryRefresh::Persister do
         2.times do |i|
           persister = TestCollector.generate_batches_of_full_container_group_data(
             :settings => settings,
-            :ems_name => @ems.name,
+            :ems_id   => @ems.id,
             :version  => bigger_newest_version,
           )
 
           TestCollector.generate_batches_of_full_container_group_data(
             :settings    => settings,
-            :ems_name    => @ems.name,
+            :ems_id      => @ems.id,
             :version     => newest_version(settings),
             :persister   => persister,
             :index_start => 1,
@@ -1011,7 +1011,7 @@ describe InventoryRefresh::Persister do
           persister = TestCollector.refresh(
             TestCollector.generate_batches_of_full_container_group_data(
               :settings    => settings,
-              :ems_name    => @ems.name,
+              :ems_id      => @ems.id,
               :version     => newest_version(settings),
               :index_start => 0,
               :batch_size  => 2

--- a/spec/persister/test_collector.rb
+++ b/spec/persister/test_collector.rb
@@ -2,9 +2,9 @@ require_relative '../helpers/test_persister/containers'
 
 class TestCollector
   class << self
-    def generate_batches_of_partial_container_group_data(ems_name:, version:, settings:, batch_size: 4, index_start: 0,
+    def generate_batches_of_partial_container_group_data(ems_id:, version:, settings:, batch_size: 4, index_start: 0,
                                                          persister: nil, resource_version: nil)
-      ems = ExtManagementSystem.find_by(:name => ems_name)
+      ems = ExtManagementSystem.find_by(:id => ems_id)
       persister ||= new_persister(ems, settings)
 
       (index_start * batch_size..((index_start + 1) * batch_size - 1)).each do |index|
@@ -15,9 +15,9 @@ class TestCollector
       persister
     end
 
-    def generate_batches_of_different_partial_container_group_data(ems_name:, version:, settings:, batch_size: 4,
+    def generate_batches_of_different_partial_container_group_data(ems_id:, version:, settings:, batch_size: 4,
                                                                    index_start: 0, persister: nil, resource_version: nil)
-      ems = ExtManagementSystem.find_by(:name => ems_name)
+      ems = ExtManagementSystem.find_by(:id => ems_id)
       persister ||= new_persister(ems, settings)
 
       (index_start * batch_size..((index_start + 1) * batch_size - 1)).each do |index|
@@ -28,9 +28,9 @@ class TestCollector
       persister
     end
 
-    def generate_batches_of_full_container_group_data(ems_name:, version:, settings:, batch_size: 4, index_start: 0,
+    def generate_batches_of_full_container_group_data(ems_id:, version:, settings:, batch_size: 4, index_start: 0,
                                                       persister: nil, resource_version: nil)
-      ems = ExtManagementSystem.find_by(:name => ems_name)
+      ems = ExtManagementSystem.find_by(:id => ems_id)
       persister ||= new_persister(ems, settings)
 
       (index_start * batch_size..((index_start + 1) * batch_size - 1)).each do |index|


### PR DESCRIPTION
It isn't guarenteed that there will be a name property on the manager
object passed in to save_inventory.