### PR TITLE
Check changed strategy for batch

### DIFF
--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -214,12 +214,17 @@ module InventoryRefresh
       false
     end
 
+    def use_ar_object?
+      true
+    end
+
     # @return [Hash] kwargs shared for all InventoryCollection objects
     def shared_options
       {
         :strategy               => strategy,
         :parent                 => manager.presence,
         :assert_graph_integrity => assert_graph_integrity?,
+        :use_ar_object          => use_ar_object?,
       }
     end
 

--- a/lib/inventory_refresh/save_collection/saver/base.rb
+++ b/lib/inventory_refresh/save_collection/saver/base.rb
@@ -89,6 +89,8 @@ module InventoryRefresh::SaveCollection
       # @param attributes [Hash] attributes hash
       # @return [Hash] modified hash from parameter attributes with casted values
       def values_for_database!(all_attribute_keys, attributes)
+        # TODO(lsmola) we'll need to fill default value from the DB to the NOT_NULL columns here, since sending NULL
+        # to column with NOT_NULL constraint always fails, even if there is a default value
         all_attribute_keys.each do |key|
           next unless attributes.key?(key)
 
@@ -100,11 +102,7 @@ module InventoryRefresh::SaveCollection
       end
 
       def transform_to_hash!(all_attribute_keys, hash)
-        if inventory_collection.use_ar_object?
-          record = inventory_collection.model_class.new(hash)
-          values_for_database!(all_attribute_keys,
-                               record.attributes.slice(*record.changed_attributes.keys).symbolize_keys)
-        elsif serializable_keys?
+        if serializable_keys?
           values_for_database!(all_attribute_keys,
                                hash)
         else

--- a/spec/persister/skeletal_precreate_spec.rb
+++ b/spec/persister/skeletal_precreate_spec.rb
@@ -299,7 +299,7 @@ describe InventoryRefresh::Persister do
           container_data(
             1,
             :container_group => persister.container_groups.lazy_find("container_group_ems_ref_1"),
-          )
+          ).merge(:command => "rm -rf /tmp")
         )
 
         persister.persist!

--- a/spec/persister/sweep_inactive_records_spec.rb
+++ b/spec/persister/sweep_inactive_records_spec.rb
@@ -39,7 +39,7 @@ describe InventoryRefresh::Persister do
           persister.refresh_state_part_uuid = part1_uuid
 
           persister.container_groups.build(container_group_data(1).merge(:resource_timestamp => time_before))
-          persister.container_groups.build(container_group_data(2).merge(:resource_timestamp => time_before))
+          persister.container_groups.build(container_group_data(2).merge(:resource_timestamp => time_before, :phase => "stopped"))
           persister.container_groups.build(container_group_data(5).merge(:resource_timestamp => time_before))
           persister = persist(persister, config)
 

--- a/spec/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/save_inventory/single_inventory_collection_spec.rb
@@ -150,8 +150,7 @@ describe InventoryRefresh::SaveInventory do
 
         # Check the InventoryCollection result matches what was created/deleted/updated
         expect(@persister.vms.created_records).to match_array([])
-        # TODO(lsmola) check changed
-        expect(@persister.vms.updated_records).to match_array([{:id => @vm1.id}, {:id => @vm2.id}])
+        expect(@persister.vms.updated_records).to match_array([{:id => @vm2.id}])
         expect(@persister.vms.deleted_records).to match_array([])
 
         # Assert that saved data have the updated values, checking id to make sure the original records are updated


### PR DESCRIPTION
Test case 1st refresh creating ~1.2M records, 2nd refresh updating ~1.2M records with no changes, with 3 persisters and 5 partitions (with this setup, 1 persister is slacking, since it get only 1 partitions assigned)

with use_ar_object => true
----------------------------------

| refresh | max saving 1 part | avg saving 1 part | total time | max memory |
| ------------- |:-------------:| :-------------:| :-------------:| :-----:|
| 1st      |  1.53s | 0.47s | 28.5m | 100MB  |
| 2nd      | 1.09s | 0.38s | 25.3m | 105MB |


with use_ar_object => false
----------------------------------

| refresh | max saving 1 part | avg saving 1 part | total time | max memory |
| ------------- |:-------------:| :-------------:| :-------------:| :-----:|
| 1st      |  1.53s | 0.47s | 28.5m | 100MB  |
| 2nd      | 1.06s | 0.28s | 25.15m | 97MB |

Evaluation
========

use_ar_object => false is a bit quicker, but it always updates everything, so it stresses the DB much more. Also by updating everything, we don't get reliable report about what was changed.
