### PR TITLE
Fix sporadic issues in specs

### DIFF
--- a/spec/helpers/spec_parsed_data.rb
+++ b/spec/helpers/spec_parsed_data.rb
@@ -59,8 +59,9 @@ module SpecParsedData
 
   def flavor_data(i, data = {})
     {
-      :name   => "t#{i}.nano",
-      :ems_id => @ems.id,
+      :name    => "t#{i}.nano",
+      :ems_ref => "t#{i}.nano",
+      :ems_id  => @ems.id,
     }.merge(data)
   end
 

--- a/spec/persister/persister_spec.rb
+++ b/spec/persister/persister_spec.rb
@@ -33,7 +33,7 @@ describe InventoryRefresh::Persister do
       @persister.add_collection(:vms)
 
       expect(@persister.vms.not_null_columns).to(
-        match_array(%i(created_on updated_on ems_ref))
+        match_array(%i(created_on updated_on ems_ref ems_id))
       )
 
       expect(@persister.vms.base_columns).to(

--- a/spec/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -68,7 +68,7 @@ describe InventoryRefresh::SaveInventory do
   let(:persister_class) { ::TestPersister }
 
   before do
-    @ems = FactoryBot.create(:ems_cloud)
+    @ems = FactoryBot.create(:ems_cloud, :network_manager => FactoryBot.create(:ems_network))
 
     allow(@ems.class).to receive(:ems_type).and_return(:mock)
     @persister = persister_class.new(@ems)
@@ -516,13 +516,21 @@ describe InventoryRefresh::SaveInventory do
     expect(vm4.hardware.virtualization_type).to eq(nil)
   end
 
+  def add_default_values(builder)
+    builder.add_default_values(
+      :ems_id => ->(persister) { persister.manager.id }
+    )
+  end
+
   def initialize_data_and_inventory_collections
     # Initialize the InventoryCollections
     @persister.add_collection(:vms) do |builder|
       builder.add_properties(:model_class => ManageIQ::Providers::CloudManager::Vm)
+      add_default_values(builder)
     end
     @persister.add_collection(:miq_templates) do |builder|
       builder.add_properties(:model_class => ManageIQ::Providers::CloudManager::Template)
+      add_default_values(builder)
     end
     @persister.add_collection(:hardwares) do |builder|
       builder.add_properties(
@@ -544,6 +552,7 @@ describe InventoryRefresh::SaveInventory do
         :model_class => ManageIQ::Providers::CloudManager::Flavor,
         :manager_ref => %i(name)
       )
+      add_default_values(builder)
     end
 
     # Get parsed data with the lazy_relations

--- a/spec/save_inventory/graph_of_inventory_collections_spec.rb
+++ b/spec/save_inventory/graph_of_inventory_collections_spec.rb
@@ -799,6 +799,12 @@ describe InventoryRefresh::SaveInventory do
     expect(orchestration_stack_resource_12_23.stack).to eq(orchestration_stack_1_12)
   end
 
+  def add_default_values(builder)
+    builder.add_default_values(
+      :ems_id => ->(persister) { persister.manager.id }
+    )
+  end
+
   # Initialize the InventoryCollections
   def initialize_inventory_collections(opts = {})
     collections = [
@@ -811,6 +817,8 @@ describe InventoryRefresh::SaveInventory do
         builder.add_properties(
           :model_class => params[1],
         )
+
+        add_default_values(builder) if params[0] == :orchestration_stacks
       end
     end
 

--- a/spec/save_inventory/saver_strategies_spec.rb
+++ b/spec/save_inventory/saver_strategies_spec.rb
@@ -17,8 +17,7 @@ describe InventoryRefresh::SaveInventory do
   ].each do |options|
     context "with options #{options}" do
       before do
-        @ems = FactoryBot.create(:ems_cloud,
-                                  :network_manager => FactoryBot.create(:ems_network))
+        @ems = FactoryBot.create(:ems_cloud, :network_manager => FactoryBot.create(:ems_network))
 
         allow(@ems.class).to receive(:ems_type).and_return(:mock)
         @persister = persister_class.new(@ems)

--- a/spec/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/save_inventory/single_inventory_collection_spec.rb
@@ -541,7 +541,7 @@ describe InventoryRefresh::SaveInventory do
     context 'with VM InventoryCollection with changed parent and association' do
       it 'deletes missing and creates new VMs with AvailabilityZone parent, ' do
         time_now = Time.now.utc
-        availability_zone = FactoryBot.create(:availability_zone, :ext_management_system => @ems)
+        availability_zone = FactoryBot.create(:availability_zone, :ext_management_system => @ems, :ems_ref => "us-east-1")
         @vm1.update_attributes(:availability_zone => availability_zone)
         @vm2.update_attributes(:availability_zone => availability_zone)
 
@@ -586,8 +586,7 @@ describe InventoryRefresh::SaveInventory do
         # Fill the InventoryCollections with data, that have one new VM and are missing one VM
         %w(1 3).each do |i|
           @persister.vms.build(vm_data(i).merge(:name                  => "vm_changed_name_#{i}",
-                                                :cloud_tenant          => cloud_tenant,
-                                                :ext_management_system => @ems))
+                                                :cloud_tenant          => cloud_tenant))
         end
 
         # Invoke the InventoryCollections saving
@@ -619,9 +618,9 @@ describe InventoryRefresh::SaveInventory do
         @persister.vms.build(vm_data(1).merge(:name         => "vm_changed_name_1",
                                               :cloud_tenant => cloud_tenant))
 
-        @persister.vms.build(vm_data(3).merge(:name                  => "vm_changed_name_3",
-                                              :cloud_tenant          => cloud_tenant,
-                                              :ext_management_system => nil))
+        @persister.vms.build(vm_data(3).merge(:name         => "vm_changed_name_3",
+                                              :cloud_tenant => cloud_tenant,
+                                              :ems_id       => FactoryBot.create(:ems_cloud).id))
 
         # Invoke the InventoryCollections saving
         InventoryRefresh::SaveInventory.save_inventory(@ems, @persister.inventory_collections)
@@ -646,8 +645,8 @@ describe InventoryRefresh::SaveInventory do
 
 
   it 'reconnects existing VM' do
-    # Fill DB with test Vms
-    @vm1 = FactoryBot.create(:vm_cloud, vm_data(1).merge(:ext_management_system => nil))
+    # Fill DB with test Vms, it should not touch VMs of other ems, but this is just example
+    @vm1 = FactoryBot.create(:vm_cloud, vm_data(1).merge(:ext_management_system => FactoryBot.create(:ems_cloud)))
     @vm2 = FactoryBot.create(:vm_cloud, vm_data(2).merge(:ext_management_system => @ems))
 
     vms_custom_reconnect_block = lambda do |inventory_collection, inventory_objects_index, attributes_index|

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -4,9 +4,9 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   enable_extension "plpgsql"
 
   create_table "availability_zones", id: :bigserial, force: :cascade do |t|
-    t.bigint "ems_id"
+    t.bigint "ems_id", null: false
     t.string "name"
-    t.string "ems_ref"
+    t.string "ems_ref", null: false
     t.string "type"
     t.datetime "archived_at"
     t.datetime "last_seen_at"
@@ -21,8 +21,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "name"
     t.text     "description"
     t.boolean  "enabled"
-    t.string   "ems_ref"
-    t.bigint   "ems_id"
+    t.string   "ems_ref", null: false
+    t.bigint   "ems_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "type"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.datetime "updated_on", null: false
     t.bigint   "storage_id"
     t.string   "guid"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.datetime "last_scan_on"
     t.datetime "last_scan_attempt_on"
     t.string   "uid_ems"
@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   end
 
   create_table "hardwares", id: :bigserial, force: :cascade do |t|
-    t.bigint  "vm_or_template_id"
+    t.bigint  "vm_or_template_id", null: false
     t.string  "config_version"
     t.string  "virtual_hw_version"
     t.string  "guest_os"
@@ -185,11 +185,11 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   add_foreign_key :hardwares, :vms, on_delete: :cascade, column: 'vm_or_template_id'
 
   create_table "disks", id: :bigserial, force: :cascade do |t|
-    t.string   "device_name"
+    t.string   "device_name", null: false
     t.string   "device_type"
     t.string   "location"
     t.string   "filename"
-    t.bigint   "hardware_id"
+    t.bigint   "hardware_id", null: false
     t.string   "mode"
     t.string   "controller_type"
     t.bigint   "size"
@@ -232,7 +232,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.bigint   "dest_vm_or_template_id"
     t.string   "source"
     t.bigint   "chain_id"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.boolean  "is_task"
     t.text     "full_data"
     t.datetime "created_on"
@@ -262,7 +262,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "middleware_deployment_name"
     t.bigint   "generating_ems_id"
     t.bigint   "physical_server_id"
-    t.string   "ems_ref"
+    t.string   "ems_ref", null: false
     t.bigint   "middleware_domain_id"
     t.string   "middleware_domain_name"
     t.bigint   "user_id"
@@ -289,7 +289,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "name"
     t.datetime "created_on"
     t.datetime "updated_on"
-    t.string   "guid"
+    t.string   "guid", null: false
     t.bigint   "zone_id"
     t.string   "type"
     t.string   "api_version"
@@ -317,8 +317,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   end
 
   create_table "flavors", id: :bigserial, force: :cascade do |t|
-    t.bigint  "ems_id"
-    t.string  "name"
+    t.bigint  "ems_id", null: false
+    t.string  "name", null: false
     t.string  "description"
     t.integer "cpus"
     t.integer "cpu_cores"
@@ -341,7 +341,6 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.datetime "last_seen_at"
     t.index ["last_seen_at"], name: "index_flavors_on_last_seen_at", using: :btree
     t.index ["archived_at"], name: "index_flavors_on_archived_at", using: :btree
-    t.index ["ems_id", "ems_ref"], name: "index_flavors_on_ems_id_and_ems_ref", unique: true, using: :btree
     t.index ["ems_id", "name"], name: "index_flavors_on_ems_id_and_name", unique: true, using: :btree
     t.index ["ems_id"], name: "index_flavors_on_ems_id", using: :btree
     t.index ["type"], name: "index_flavors_on_type", using: :btree
@@ -358,7 +357,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.datetime "created_on"
     t.datetime "updated_on"
     t.string   "guid"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.string   "user_assigned_os"
     t.string   "power_state",             default: ""
     t.integer  "smart"
@@ -375,7 +374,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "mac_address"
     t.string   "type"
     t.boolean  "failover"
-    t.string   "ems_ref"
+    t.string   "ems_ref", null: false
     t.boolean  "hyperthreading"
     t.bigint   "ems_cluster_id"
     t.integer  "next_available_vnc_port"
@@ -398,9 +397,9 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   end
 
   create_table "networks", id: :bigserial, force: :cascade do |t|
-    t.bigint   "hardware_id"
+    t.bigint   "hardware_id", null: false
     t.bigint   "device_id"
-    t.string   "description"
+    t.string   "description", null: false
     t.string   "guid"
     t.boolean  "dhcp_enabled"
     t.string   "ipaddress"
@@ -425,8 +424,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   create_table "network_ports", id: :bigserial, force: :cascade do |t|
     t.string  "type"
     t.string  "name"
-    t.string  "ems_ref"
-    t.bigint  "ems_id"
+    t.string  "ems_ref", null: false
+    t.bigint  "ems_id", null: false
     t.string  "mac_address"
     t.string  "status"
     t.boolean "admin_state_up"
@@ -458,8 +457,8 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "resource_status"
     t.text     "resource_status_reason"
     t.datetime "last_updated"
-    t.bigint   "stack_id"
-    t.text     "ems_ref"
+    t.bigint   "stack_id", null: false
+    t.text     "ems_ref", null: false
     t.datetime "start_time"
     t.datetime "finish_time"
     t.datetime "archived_at"
@@ -475,9 +474,9 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "type"
     t.text     "description"
     t.string   "status"
-    t.text     "ems_ref"
+    t.text     "ems_ref", null: false
     t.string   "ancestry"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.bigint   "orchestration_template_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -508,11 +507,11 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   end
 
   create_table "physical_servers", id: :bigserial, force: :cascade do |t|
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.string   "name"
     t.string   "type"
     t.string   "uid_ems"
-    t.string   "ems_ref"
+    t.string   "ems_ref", null: false
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.string   "health_state"
@@ -539,7 +538,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   end
 
   create_table "container_groups", id: :bigserial, force: :cascade do |t|
-    t.string   "ems_ref"
+    t.string   "ems_ref", null: false
     t.string   "name"
     t.datetime "ems_created_on"
     t.string   "resource_version_string"
@@ -599,7 +598,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   add_foreign_key "container_group_tags", "tags", on_delete: :cascade
 
   create_table "containers", id: :bigserial, force: :cascade do |t|
-    t.string   "ems_ref"
+    t.string   "ems_ref", null: false
     t.integer  "restart_count"
     t.string   "state"
     t.string   "name"
@@ -652,7 +651,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "ems_ref"
     t.integer  "restart_count"
     t.string   "state"
-    t.string   "name"
+    t.string   "name", null: false
     t.string   "backing_ref"
     t.datetime "last_perf_capture_on"
     t.string   "type"
@@ -699,16 +698,16 @@ ActiveRecord::Schema.define(version: 20180906121026) do
 
   create_table "container_image_registries", id: :bigserial, force: :cascade do |t|
     t.string "name"
-    t.string "host"
-    t.string "port"
-    t.bigint "ems_id"
+    t.string "host", null: false
+    t.string "port", null: false
+    t.bigint "ems_id", null: false
     t.index ["ems_id", "host", "port"], name: "index_container_image_registries_on_ems_id_and_host_and_port", unique: true, using: :btree
   end
 
   create_table "container_images", id: :bigserial, force: :cascade do |t|
     t.string   "tag"
     t.string   "name"
-    t.string   "image_ref"
+    t.string   "image_ref", null: false
     t.bigint   "container_image_registry_id"
     t.bigint   "ems_id", null: false
     t.datetime "last_sync_on"
@@ -736,12 +735,12 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   end
 
   create_table "container_projects", id: :bigserial, force: :cascade do |t|
-    t.string   "ems_ref"
+    t.string   "ems_ref", null: false
     t.string   "name"
     t.datetime "ems_created_on"
     t.string   "resource_version_string"
     t.string   "display_name"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.datetime "created_on"
     t.datetime "archived_at"
     t.bigint   "old_ems_id"
@@ -753,10 +752,10 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   end
 
   create_table "container_replicators", id: :bigserial, force: :cascade do |t|
-    t.string   "ems_ref"
+    t.string   "ems_ref", null: false
     t.string   "name"
     t.datetime "ems_created_on"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.string   "resource_version_string"
     t.integer  "replicas"
     t.integer  "current_replicas"
@@ -766,11 +765,11 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   end
 
   create_table "container_nodes", id: :bigserial, force: :cascade do |t|
-    t.string   "ems_ref"
+    t.string   "ems_ref", null: false
     t.string   "name"
     t.datetime "ems_created_on"
     t.string   "resource_version_string"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.string   "lives_on_type"
     t.bigint   "lives_on_id"
     t.datetime "last_perf_capture_on"
@@ -794,7 +793,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
   end
 
   create_table "container_build_pods", id: :bigserial, force: :cascade do |t|
-    t.string   "ems_ref"
+    t.string   "ems_ref", null: false
     t.string   "name", null: false
     t.datetime "ems_created_on"
     t.string   "resource_version_string"
@@ -807,7 +806,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
     t.string   "start_timestamp"
     t.bigint   "duration"
     t.bigint   "container_build_id"
-    t.bigint   "ems_id"
+    t.bigint   "ems_id", null: false
     t.datetime "created_on"
     t.datetime "last_seen_at"
     t.index ["last_seen_at"], name: "index_container_build_pods_on_last_seen_at", using: :btree
@@ -818,7 +817,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
 
   create_table "source_regions", force: :cascade do |t|
     t.bigint "ems_id", null: false
-    t.string "ems_ref"
+    t.string "ems_ref", null: false
     t.string "name"
     t.string "endpoint"
     t.datetime "created_at", null: false
@@ -833,7 +832,7 @@ ActiveRecord::Schema.define(version: 20180906121026) do
 
   create_table "subscriptions", force: :cascade do |t|
     t.bigint "ems_id", null: false
-    t.string "ems_ref"
+    t.string "ems_ref", null: false
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Due to missing NOT_NULL constraints, there were duplicates in the DB, since the unique constraint doesn't cover null values. So we needed to add missing NOT_NULL constraints and fix the specs