### PR TITLE
Allow objects to be unarchived

### DIFF
--- a/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/lib/inventory_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -217,6 +217,8 @@ module InventoryRefresh::SaveCollection
       def changed?(record)
         return true unless inventory_collection.check_changed?
 
+        # If object was archived before, pass it to update so it can be unarchived
+        return true if record.respond_to?(:archived_at) && record.archived_at
         # Skip if nothing changed
         return false if record.changed_attributes.empty?
         # Skip if we only changed the resource_timestamp, but data stays the same


### PR DESCRIPTION
We need to treat record that is archived as 'changed' so
it proceeds to update and is unarchived.