### PR TITLE
Relax the bundler version requirement

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,6 +34,7 @@ engines:
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'
+    channel: rubocop-0-69
 prepare:
   fetch:
   - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-- 2.4.4
-- 2.3.6
+- 2.5.7
+- 2.6.5
 addons:
   postgresql: '10'
 env:

--- a/inventory_refresh.gemspec
+++ b/inventory_refresh.gemspec
@@ -31,5 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_bot", "~> 4.11.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "simplecov"
 end

--- a/inventory_refresh.gemspec
+++ b/inventory_refresh.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pg", "> 0"
 
   spec.add_development_dependency "ancestry"
-  spec.add_development_dependency "bundler", "~> 2.0.1"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "factory_bot", "~> 4.11.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Relax the requirement on bundler from 2.0.1 to just 2.1 and test more recent ruby versions since simplecov fails on ruby versions < 2.3