### PR TITLE
[WIP] Add relations to last refresh_state_part

### DIFF
--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -86,6 +86,7 @@ module InventoryRefresh
 
     # Persists InventoryCollection objects into the DB
     def persist!
+      link_data_to_refresh_state_part
       InventoryRefresh::SaveInventory.save_inventory(manager, inventory_collections)
     end
 
@@ -240,6 +241,19 @@ module InventoryRefresh
         serializer = InventoryRefresh::InventoryCollection::Serialization.new(inventory_collection)
 
         obj[k] = serializer.sweep_scope_to_hash(v)
+      end
+    end
+
+    #
+    def link_data_to_refresh_state_part
+      refresh_state_part = RefreshStatePart.where(:uuid => refresh_state_part_uuid).first
+      if refresh_state_part.present?
+        ics = inventory_collections.select { |ic| ic.data.present? }
+        ics.each do |ic|
+          ic.data.each do |inventory_object|
+            inventory_object.data[:refresh_state_part_id] = refresh_state_part.id
+          end
+        end
       end
     end
   end

--- a/lib/inventory_refresh/version.rb
+++ b/lib/inventory_refresh/version.rb
@@ -1,3 +1,3 @@
 module InventoryRefresh
-  VERSION = "0.3.3".freeze
+  VERSION = "0.3.4".freeze
 end


### PR DESCRIPTION
"Backend" for https://github.com/RedHatInsights/topological_inventory-core/pull/183

Adds "refresh_state_part_id" relation to all received data before saving (to InventoryObject's data)