### PR TITLE
Persister's Refresh tracking timestamps

### DIFF
--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -5,13 +5,15 @@ module InventoryRefresh
 
     attr_reader :manager, :collections
 
-    attr_accessor :refresh_state_uuid, :refresh_state_part_uuid, :total_parts, :sweep_scope, :retry_count, :retry_max
+    attr_accessor :refresh_state_uuid, :refresh_state_part_uuid, :refresh_time_tracking, :total_parts, :sweep_scope, :retry_count, :retry_max
 
     # @param manager [ManageIQ::Providers::BaseManager] A manager object
     def initialize(manager)
       @manager = manager
 
       @collections = {}
+
+      self.refresh_time_tracking = {:persister_started_at => Time.now.utc.to_datetime.to_s}
 
       initialize_inventory_collections
     end
@@ -107,6 +109,7 @@ module InventoryRefresh
       {
         :refresh_state_uuid      => refresh_state_uuid,
         :refresh_state_part_uuid => refresh_state_part_uuid,
+        :refresh_time_tracking   => refresh_time_tracking,
         :retry_count             => retry_count,
         :retry_max               => retry_max,
         :total_parts             => total_parts,
@@ -143,6 +146,15 @@ module InventoryRefresh
           persister.retry_max               = persister_data['retry_max']
           persister.total_parts             = persister_data['total_parts']
           persister.sweep_scope             = sweep_scope_from_hash(persister_data['sweep_scope'], persister.collections)
+          %i[
+            refresh_state_part_collected_at
+            refresh_state_part_sent_at
+            refresh_state_started_at
+            refresh_state_sent_at
+            ingress_api_sent_at
+          ].each do |timestamp_name|
+            persister.refresh_time_tracking[timestamp_name] = persister_data[timestamp_name.to_s]
+          end
         end
       end
 

--- a/lib/inventory_refresh/persister.rb
+++ b/lib/inventory_refresh/persister.rb
@@ -6,6 +6,9 @@ module InventoryRefresh
     attr_reader :manager, :collections
 
     attr_accessor :refresh_state_uuid, :refresh_state_part_uuid, :refresh_time_tracking, :total_parts, :sweep_scope, :retry_count, :retry_max
+    attr_accessor :persister_started_at, :persister_finished_at,
+                  :refresh_state_part_collected_at, :refresh_state_part_sent_at,
+                  :refresh_state_started_at, :refresh_state_sent_at, :ingress_api_sent_at
 
     # @param manager [ManageIQ::Providers::BaseManager] A manager object
     def initialize(manager)
@@ -13,7 +16,7 @@ module InventoryRefresh
 
       @collections = {}
 
-      self.refresh_time_tracking = {:persister_started_at => Time.now.utc.to_datetime.to_s}
+      self.persister_started_at = Time.now.utc.to_datetime.to_s
 
       initialize_inventory_collections
     end
@@ -107,14 +110,19 @@ module InventoryRefresh
       end.compact
 
       {
-        :refresh_state_uuid      => refresh_state_uuid,
-        :refresh_state_part_uuid => refresh_state_part_uuid,
-        :refresh_time_tracking   => refresh_time_tracking,
-        :retry_count             => retry_count,
-        :retry_max               => retry_max,
-        :total_parts             => total_parts,
-        :sweep_scope             => sweep_scope_to_hash(sweep_scope),
-        :collections             => collections_data,
+        :refresh_state_uuid              => refresh_state_uuid,
+        :refresh_state_part_uuid         => refresh_state_part_uuid,
+        :refresh_state_part_collected_at => refresh_state_part_collected_at,
+        :refresh_state_part_sent_at      => refresh_state_part_sent_at,
+        :refresh_state_started_at        => refresh_state_started_at,
+        :refresh_state_sent_at           => refresh_state_sent_at,
+        :ingress_api_sent_at             => ingress_api_sent_at,
+        :refresh_time_tracking           => refresh_time_tracking,
+        :retry_count                     => retry_count,
+        :retry_max                       => retry_max,
+        :total_parts                     => total_parts,
+        :sweep_scope                     => sweep_scope_to_hash(sweep_scope),
+        :collections                     => collections_data,
       }
     end
 
@@ -140,21 +148,17 @@ module InventoryRefresh
             inventory_collection.from_hash(collection, persister.collections)
           end
 
-          persister.refresh_state_uuid      = persister_data['refresh_state_uuid']
-          persister.refresh_state_part_uuid = persister_data['refresh_state_part_uuid']
-          persister.retry_count             = persister_data['retry_count']
-          persister.retry_max               = persister_data['retry_max']
-          persister.total_parts             = persister_data['total_parts']
-          persister.sweep_scope             = sweep_scope_from_hash(persister_data['sweep_scope'], persister.collections)
-          %i[
-            refresh_state_part_collected_at
-            refresh_state_part_sent_at
-            refresh_state_started_at
-            refresh_state_sent_at
-            ingress_api_sent_at
-          ].each do |timestamp_name|
-            persister.refresh_time_tracking[timestamp_name] = persister_data[timestamp_name.to_s]
-          end
+          persister.refresh_state_uuid              = persister_data['refresh_state_uuid']
+          persister.refresh_state_part_uuid         = persister_data['refresh_state_part_uuid']
+          persister.refresh_state_part_collected_at = persister_data['refresh_state_part_collected_at']
+          persister.refresh_state_part_sent_at      = persister_data['refresh_state_part_sent_at']
+          persister.refresh_state_started_at        = persister_data['refresh_state_started_at']
+          persister.refresh_state_sent_at           = persister_data['refresh_state_sent_at']
+          persister.ingress_api_sent_at             = persister_data['ingress_api_sent_at']
+          persister.retry_count                     = persister_data['retry_count']
+          persister.retry_max                       = persister_data['retry_max']
+          persister.total_parts                     = persister_data['total_parts']
+          persister.sweep_scope                     = sweep_scope_from_hash(persister_data['sweep_scope'], persister.collections)
         end
       end
 

--- a/lib/inventory_refresh/version.rb
+++ b/lib/inventory_refresh/version.rb
@@ -1,3 +1,3 @@
 module InventoryRefresh
-  VERSION = "0.3.3".freeze
+  VERSION = "0.3.4".freeze
 end

--- a/spec/helpers/test_persister.rb
+++ b/spec/helpers/test_persister.rb
@@ -12,12 +12,8 @@ class TestPersister < InventoryRefresh::Persister
   end
 
   def initialize(manager, extra_options = {})
-    @manager = manager
-
-    @collections = {}
     @options     = extra_options
-
-    initialize_inventory_collections
+    super(manager)
   end
 
   def assert_graph_integrity?


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-persister/issues/52

Collecting timestamps from refresh on persister:
- refresh_state_part_collected_at
- refresh_state_part_sent_at
- refresh_state_started_at
- refresh_state_sent_at
- ingress_api_sent_at

adds one:
- persister_started_at
