### PR TITLE
bump more core extensions

### DIFF
--- a/inventory_refresh.gemspec
+++ b/inventory_refresh.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", "~> 5.0"
-  spec.add_dependency "more_core_extensions", "~> 3.5"
+  spec.add_dependency "more_core_extensions", ">=3.5", "< 5"
   spec.add_dependency "pg", "> 0"
 
   spec.add_development_dependency "ancestry"


### PR DESCRIPTION
more core ext's on 4.1.0

update for update sake

https://github.com/ManageIQ/more_core_extensions/compare/179bf40..e5b4501
 - Added Ruby 2.7 support [[#79](https://github.com/ManageIQ/more_core_extensions/pull/79)]
 - Added Process#pause, Process#resume, and Process#alive? [[#73](https://github.com/ManageIQ/more_core_extensions/pull/73)]

array added * `#compact_map` - Collect non-nil results from the block
array added `#tabular_sort` - Sorts an Array of Hashes by specific columns

hierarchy added `#descendant_get` - Returns the descendant with a given name

the two breaking changes:
- **BREAKING**: Moved Object#descendant_get to Class#descendant_get [[#75](https://github.com/ManageIQ/more_core_extensions/pull/75)]
- **BREAKING**: Removed deprecated Enumerable#stable_sort_by [[#76](https://github.com/ManageIQ/more_core_extensions/pull/76)]

a minor header output change was made that hasn't been released yet to make tableize more markdown compliant

see https://github.com/ManageIQ/linux_admin/pull/221