### PR TITLE
cleanup .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: xenial
-sudo: false
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
I expect we don't need to list the default distro and we also no longer need `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration