### PR TITLE
rails 6.1: s/arel_attribute/arel_table/

### DIFF
--- a/lib/inventory_refresh/save_collection/saver/base.rb
+++ b/lib/inventory_refresh/save_collection/saver/base.rb
@@ -19,7 +19,7 @@ module InventoryRefresh::SaveCollection
         @table_name             = @model_class.table_name
         @q_table_name           = get_connection.quote_table_name(@table_name)
         @primary_key            = @model_class.primary_key
-        @arel_primary_key       = @model_class.arel_attribute(@primary_key)
+        @arel_primary_key       = @model_class.arel_table[@primary_key]
         @unique_index_keys      = inventory_collection.unique_index_keys
         @unique_index_keys_to_s = inventory_collection.manager_ref_to_cols.map(&:to_s)
         @select_keys            = [@primary_key] + @unique_index_keys_to_s + internal_columns.map(&:to_s)


### PR DESCRIPTION
`arel_attribute` has gone away
Since this is referring to the primary key,
this works for us in all versions of rails

So no need to turn key merge this with manageiq core.