### PR TITLE
Remove deprecated find_by/lazy_find_by methods

### DIFF
--- a/lib/inventory_refresh/inventory_collection/index/proxy.rb
+++ b/lib/inventory_refresh/inventory_collection/index/proxy.rb
@@ -77,7 +77,6 @@ module InventoryRefresh
         end
 
         def find(reference, ref: primary_index_ref)
-          # TODO(lsmola) lazy_find will support only hash, then we can remove the _by variant
           # TODO(lsmola) this method should return lazy too, the rest of the finders should be deprecated
           return if reference.nil?
 
@@ -95,21 +94,9 @@ module InventoryRefresh
           end
         end
 
-        def find_by(manager_uuid_hash, ref: primary_index_ref)
-          # TODO(lsmola) deprecate this, it's enough to have find method
-          find(manager_uuid_hash, :ref => ref)
-        end
-
-        def lazy_find_by(manager_uuid_hash, ref: primary_index_ref, key: nil, default: nil)
-          # TODO(lsmola) deprecate this, it's enough to have lazy_find method
-
-          lazy_find(manager_uuid_hash, :ref => ref, :key => key, :default => default)
-        end
-
         def lazy_find(manager_uuid, ref: primary_index_ref, key: nil, default: nil, transform_nested_lazy_finds: false)
           # TODO(lsmola) also, it should be enough to have only 1 find method, everything can be lazy, until we try to
           # access the data
-          # TODO(lsmola) lazy_find will support only hash, then we can remove the _by variant
           return if manager_uuid.nil?
 
           assert_index(manager_uuid, ref)


### PR DESCRIPTION
The "standard" find() and lazy_find() methods have been able to take a hash for the ref for a long time making the `*find_by()` methods obsolete.

This is a breaking change and will require a major version bump