### PR TITLE
Allow rails 7 gems in gemspec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,9 @@ jobs:
         - '3.0'
         rails-version:
         # rails 6.1 supports ruby >= 2.5
+        # rails 7.0 supports ruby >= 2.7
         - '6.1'
+        - '7.0'
         include:
         # rails 5.2 (EOL 6/22) supports ruby < 2.7 (2.6 EOL 3/22)
         - ruby-version: '2.5'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
         ruby-version:
         - '2.7'
         - '3.0'
+        - '3.1'
         rails-version:
         # rails 6.1 supports ruby >= 2.5
         # rails 7.0 supports ruby >= 2.7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,6 @@ jobs:
         - '6.1'
         - '7.0'
         include:
-        # rails 5.2 (EOL 6/22) supports ruby < 2.7 (2.6 EOL 3/22)
-        - ruby-version: '2.5'
-          rails-version: '5.2'
         # rails 6.0 (security EOL 6/23?) supports ruby < 2.8 (2.7 EOL 3/23?;)
         - ruby-version: '2.6'
           rails-version: '6.0'

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,12 @@ namespace :spec do
 
   def connection_spec
     require 'yaml'
-    @connection_spec ||= YAML.load_file(File.join(__dir__, %w[config database.yml]))
+    @connection_spec ||=
+      if YAML.respond_to?(:safe_load)
+        YAML.safe_load(File.read(File.join(__dir__, %w[config database.yml])), :aliases => true)
+      else
+        YAML.load_file(File.join(__dir__, %w[config database.yml]))
+      end
   end
 
   def test_database_name

--- a/inventory_refresh.gemspec
+++ b/inventory_refresh.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_dependency "activerecord", ">=5.0", "< 7.0"
+  spec.add_dependency "activerecord", ">=5.0", "<7.1"
   spec.add_dependency "more_core_extensions", ">=3.5", "< 5"
   spec.add_dependency "pg", "> 0"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,5 +28,10 @@ puts
 puts "\e[93mUsing ActiveRecord #{ActiveRecord.version}\e[0m"
 
 require 'yaml'
-connection_spec = YAML.load_file(File.join(__dir__, %w[.. config database.yml]))
+connection_spec =
+  if YAML.respond_to?(:safe_load)
+    YAML.safe_load(File.read(File.join(__dir__, %w[.. config database.yml])), :aliases => true)
+  else
+    YAML.load_file(File.join(__dir__, %w[.. config database.yml]))
+  end
 ActiveRecord::Base.establish_connection(connection_spec["test"])


### PR DESCRIPTION
Allow rails 7 gems in gemspec

Note, I dropped ruby 2.5/rails 5.2 from the matrix since they are far EOL.