### PR TITLE
Log destroy result when duplicate record is found

### DIFF
--- a/lib/inventory_refresh/save_collection/saver/default.rb
+++ b/lib/inventory_refresh/save_collection/saver/default.rb
@@ -43,9 +43,9 @@ module InventoryRefresh::SaveCollection
         if unique_db_indexes.include?(index) # Include on Set is O(1)
           # We have a duplicate in the DB, destroy it. A find_each method does automatically .order(:id => :asc)
           # so we always keep the oldest record in the case of duplicates.
-          logger.warn("A duplicate record was detected and destroyed, inventory_collection: "\
+          destroyed = record.destroy ? "and destroyed" : "but could not be destroyed"
+          logger.warn("A duplicate record was detected #{destroyed}, inventory_collection:" \
                       "'#{inventory_collection}', record: '#{record}', duplicate_index: '#{index}'")
-          record.destroy
           return false
         else
           unique_db_indexes << index


### PR DESCRIPTION
When a duplicate record is found, a message is logged that the record has been detected *and destroyed* before attempting to destroy the record. If the destroy returns False, and the record is not destroyed, nothing is logged. This happens in the case of a read-only record.

An alternate solution could be to call destroy! so that an 'ActiveRecord::RecordNotDestroyed' exception is raised if the record is not destroyed, and read-only records could be handled in a rescue block.