### PR TITLE
[WIP] Fix ActiveRecord::Base.default_timezone deprecation

### DIFF
--- a/lib/inventory_refresh/save_collection/saver/base.rb
+++ b/lib/inventory_refresh/save_collection/saver/base.rb
@@ -272,7 +272,7 @@ module InventoryRefresh::SaveCollection
       # @return [Time] A rails friendly time getting config from ActiveRecord::Base.default_timezone (can be :local
       #         or :utc)
       def time_now
-        if ActiveRecord::Base.default_timezone == :utc
+        if ActiveRecord.default_timezone == :utc
           Time.now.utc
         else
           Time.zone.now


### PR DESCRIPTION
```
DEPRECATION WARNING: ActiveRecord::Base.default_timezone is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.default_timezone` instead.
 (called from time_now at /home/grare/adam/src/manageiq/inventory_refresh/lib/inventory_refresh/save_collection/saver/base.rb:277)
 ```