### PR TITLE
Fix rails 7 deprecation on ActiveRecord::Base.default_timezone

### DIFF
--- a/lib/inventory_refresh/save_collection/saver/base.rb
+++ b/lib/inventory_refresh/save_collection/saver/base.rb
@@ -269,14 +269,8 @@ module InventoryRefresh::SaveCollection
         true
       end
 
-      # @return [Time] A rails friendly time getting config from ActiveRecord::Base.default_timezone (can be :local
-      #         or :utc)
       def time_now
-        if ActiveRecord::Base.default_timezone == :utc
-          Time.now.utc
-        else
-          Time.zone.now
-        end
+        Time.current
       end
 
       # Enriches data hash with timestamp columns


### PR DESCRIPTION
Rails 7 added ActiveRecord.default_timezone and 7.1 will remove it from ActiveRecord::Base.

Extract a memoized method to hide this logic.

Fixes this deprecation in the 7.0 test suite:
```
DEPRECATION WARNING: ActiveRecord::Base.default_timezone is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.default_timezone` instead.
 (called from time_now at /home/runner/work/inventory_refresh/inventory_refresh/lib/inventory_refresh/save_collection/saver/base.rb:275)
```