### PR TITLE
Fix missing constant OpenStruct in tests

### DIFF
--- a/spec/graph_spec.rb
+++ b/spec/graph_spec.rb
@@ -1,4 +1,6 @@
 describe InventoryRefresh::Graph do
+  require "ostruct"
+
   let(:node1) { OpenStruct.new(:whatever => 'foo') }
   let(:node2) { OpenStruct.new(:name => 'bar', :x => 2) }
   let(:node3) { OpenStruct.new(:name => 'bar', :x => 3) }


### PR DESCRIPTION
Fixes 


```
Failures:

  1) InventoryRefresh::Graph#to_graphviz prints the graph
     Failure/Error: let(:node1) { OpenStruct.new(:whatever => 'foo') }
     
     NameError:
       uninitialized constant OpenStruct
     
         let(:node1) { OpenStruct.new(:whatever => 'foo') }
              
  2) InventoryRefresh::Graph#to_graphviz prints the graph with layers
     Failure/Error: let(:node1) { OpenStruct.new(:whatever => 'foo') }
     
     NameError:
       uninitialized constant OpenStruct
     
         let(:node1) { OpenStruct.new(:whatever => 'foo') }
        
Finished in 13.96 seconds (files took 0.76564 seconds to load)
235 examples, 2 failures, 2 pending

Failed examples:

rspec ./spec/graph_spec.rb:22 # InventoryRefresh::Graph#to_graphviz prints the graph
rspec ./spec/graph_spec.rb:38 # InventoryRefresh::Graph#to_graphviz prints the graph with layers
```

https://github.com/ManageIQ/inventory_refresh/actions/runs/8856834572/job/24323579863?pr=130#step:6:139
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
