### PR TITLE
Fix the broken test matrix and drop old rubies and rails (breaking change)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,22 +12,17 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
         - '3.0'
         - '3.1'
         - '3.2'
+        - '3.3'
         rails-version:
-        # rails 6.1 supports ruby >= 2.5
-        # rails 7.0 supports ruby >= 2.7
-        - '6.1'
         - '7.0'
         - '7.1'
-        include:
-        # rails 6.0 (security EOL 6/23?) supports ruby < 2.8 (2.7 EOL 3/23?;)
-        - ruby-version: '2.6'
-          rails-version: '6.0'
-        - ruby-version: '2.7'
-          rails-version: '6.0'
+        - '7.2'
+        exclude:
+        - ruby-version: '3.0'
+          rails-version: '7.2'
     services:
       postgres:
         image: manageiq/postgresql:13

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,14 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 # Specify your gem's dependencies in inventory_refresh.gemspec
 gemspec
 
-case ENV['TEST_RAILS_VERSION']
-when "5.2"
-  gem "activerecord", "~>5.2.6"
-when "6.0"
-  gem "activerecord", "~>6.0.4"
-when "6.1"
-  gem "activerecord", "~>6.1.4"
-end
+minimum_version =
+  case ENV['TEST_RAILS_VERSION']
+  when "7.2"
+    "~>7.2.1"
+  when "7.1"
+    "~>7.1.4"
+  else
+    "~>7.0.8"
+  end
+
+gem "activerecord", minimum_version

--- a/inventory_refresh.gemspec
+++ b/inventory_refresh.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_dependency "activerecord", ">=5.0", "<7.2"
+  spec.required_ruby_version = '>= 3.0'
+  spec.add_dependency "activerecord", ">=7.0.8", "<8.0"
   spec.add_dependency "more_core_extensions", ">=3.5", "< 5"
   spec.add_dependency "pg", "> 0"
 

--- a/lib/inventory_refresh/inventory_collection/index/proxy.rb
+++ b/lib/inventory_refresh/inventory_collection/index/proxy.rb
@@ -111,7 +111,8 @@ module InventoryRefresh
 
           raise ArgumentError, "only one of manager_uuid or manager_uuid_hash must be passed" unless !!manager_uuid ^ !!manager_uuid_hash.present?
 
-          ActiveSupport::Deprecation.warn("Passing a hash for options is deprecated and will be removed in an upcoming release.") if opts.present?
+          # TODO: switch to ActiveSupport.deprecator.warn once 7.1+ is a minimum, see: https://github.com/rails/rails/pull/47354
+          ActiveSupport::Deprecation.new.warn("Passing a hash for options is deprecated and will be removed in an upcoming release.") if opts.present?
 
           manager_uuid ||= manager_uuid_hash
 


### PR DESCRIPTION
### Fix the broken test matrix and drop old rubies and rails

The ci.yaml matrix of rubies and rails versions didn't match the case statement in the Gemfile.  Rails 7.0 and 7.1 were not included in the case statement previously.

Now, we sync them up and make the following changes:

Drop:
* ruby 2.7
* rails 6.0
* rails 6.1

Add:
* ruby 3.3
* rails 7.2

We set a minimum ruby version of 3.0 and rails 7.0.8 and allow versions less than 8.0, so we can test with 7.1 and 7.2.


### Rails 7.1 deprecated and 7.2 removed access to the deprecator instance

See: https://www.github.com/rails/rails/pull/47354

For now, we can maintain support for 7.0-7.2 by manually instantiating the object
and not pass an explicit deprecator.