### PR TITLE
Add support for rails 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,14 @@ jobs:
         - '7.0'
         - '7.1'
         - '7.2'
+        - '8.0'
         exclude:
         - ruby-version: '3.0'
           rails-version: '7.2'
+        - ruby-version: '3.0'
+          rails-version: '8.0'
+        - ruby-version: '3.1'
+          rails-version: '8.0'
     services:
       postgres:
         image: manageiq/postgresql:13

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gemspec
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
+  when "8.0"
+    "~>8.0.4"
   when "7.2"
     "~>7.2.1"
   when "7.1"

--- a/inventory_refresh.gemspec
+++ b/inventory_refresh.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.required_ruby_version = '>= 3.0'
-  spec.add_dependency "activerecord", ">=7.0.8", "<8.0"
+  spec.add_dependency "activerecord", ">=7.0.8", "<8.1"
   spec.add_dependency "more_core_extensions", ">=3.5", "< 5"
   spec.add_dependency "pg", "> 0"
 


### PR DESCRIPTION
No test failures but I'm seeing a logged error regarding a missing index:

```
Using ActiveRecord 8.0.4

Randomized with seed 16682
.......................................E, [2025-12-10T16:12:03.223343 #61586] ERROR -- : Error when saving InventoryCollection:<Hardware> with strategy: , saver_strategy: default, targeted: false. Message: Referential integrity check violated for {:bitness=>"64", :virtualization_type=>"virtualization_type_1", :vm_or_template_id=>nil} of InventoryCollection:<Hardware> because of missing foreign key vm_or_template_id for ManageIQ::Providers::CloudManager:344
.E, [2025-12-10T16:12:03.232580 #61586] ERROR -- : Error when saving InventoryCollection:<Hardware> with strategy: , saver_strategy: default, targeted: false. Message: Referential integrity check violated for {:bitness=>"64", :virtualization_type=>"virtualization_type_1", :vm_or_template_id=>nil} of InventoryCollection:<Hardware> because of missing foreign key vm_or_template_id for ManageIQ::Providers::CloudManager:345
............................*...............................*............E, [2025-12-10T16:12:08.269008 #61586] ERROR -- : Error when asserting index: {:hardwares=>"something", :description=>"public"}, with ref: manager_ref of: InventoryCollection:<Network>, strategy: local_db_find_missing_references
E, [2025-12-10T16:12:08.269091 #61586] ERROR -- : Error when asserting index: {:ems_ruf=>"some_ems_ref"}, with ref: manager_ref of: InventoryCollection:<Vm>, blacklist: [genealogy_parent], strategy: local_db_find_missing_references
..E, [2025-12-10T16:12:08.286938 #61586] ERROR -- : Error when asserting index: {:vm_or_template=>"not_allowed_string"}, with ref: manager_ref of: InventoryCollection:<Hardware>, strategy: local_db_find_missing_references
E, [2025-12-10T16:12:08.287015 #61586] ERROR -- : Error when asserting index: not_allowed_string, with ref: manager_ref of: InventoryCollection:<Hardware>, strategy: local_db_find_missing_references
.E, [2025-12-10T16:12:08.294061 #61586] ERROR -- : Error when asserting index: {:names=>"name"}, with ref: by_name of: InventoryCollection:<Vm>, blacklist: [genealogy_parent], strategy: local_db_find_missing_references
E, [2025-12-10T16:12:08.294148 #61586] ERROR -- : Error when asserting index: {:names=>"name", :uida_ems=>"uid_ems"}, with ref: by_uid_ems_and_name of: InventoryCollection:<Vm>, blacklist: [genealogy_parent], strategy: local_db_find_missing_references
.DEPRECATION WARNING: Passing a hash for options is deprecated and will be removed in an upcoming release. (called from lazy_find at /Users/joerafaniello/Code/inventory_refresh/lib/inventory_refresh/inventory_collection.rb:122)
DEPRECATION WARNING: Passing a hash for options is deprecated and will be removed in an upcoming release. (called from lazy_find at /Users/joerafaniello/Code/inventory_refresh/lib/inventory_refresh/inventory_collection.rb:122)
.......E, [2025-12-10T16:12:08.371443 #61586] ERROR -- : Error when asserting index: unknown__public, with ref: manager_ref of: InventoryCollection:<Disk>, strategy: local_db_find_missing_references
...............................................................................................................
```